### PR TITLE
Add API for completed classes attendance

### DIFF
--- a/src/controller/student/student.controller.ts
+++ b/src/controller/student/student.controller.ts
@@ -181,6 +181,47 @@ export class StudentController {
     return await this.studentService.getAttendanceClass(req.user[0].id);
   }
 
+  @Get('/bootcamp/:bootcampId/completed-classes')
+  @ApiOperation({ summary: 'Get completed classes with attendance for a bootcamp' })
+  @ApiBearerAuth()
+  @ApiQuery({
+    name: 'limit',
+    type: Number,
+    description: 'Number of items per page',
+    required: false
+  })
+  @ApiQuery({
+    name: 'offset',
+    type: Number,
+    description: 'Offset for pagination',
+    required: false
+  })
+  async getCompletedClassesWithAttendance(
+    @Req() req,
+    @Param('bootcampId') bootcampId: number,
+    @Query('limit') limit: number,
+    @Query('offset') offset: number,
+    @Res() res: Response
+  ) {
+    try {
+      const parsedLimit = limit ? Number(limit) : 10;
+      const parsedOffset = offset ? Number(offset) : 0;
+      const [err, success] = await this.studentService.getCompletedClassesWithAttendance(
+        req.user[0].id,
+        bootcampId,
+        parsedLimit,
+        parsedOffset,
+      );
+      if (err) {
+        return ErrorResponse.BadRequestException(err.message).send(res);
+      }
+      const result: any = success;
+      return new SuccessResponse(result.message, result.statusCode, result.data).send(res);
+    } catch (error) {
+      return ErrorResponse.BadRequestException(error.message).send(res);
+    }
+  }
+
 
   @Get('/leaderboard/:bootcampId')
   @ApiOperation({ summary: 'Get the leaderboard of a course' })

--- a/src/controller/student/student.service.ts
+++ b/src/controller/student/student.service.ts
@@ -726,13 +726,20 @@ export class StudentService {
       const result = paginatedClasses.map((cls) => {
         const students = attendanceMap.get(cls.meetingId) || [];
         const studentRecord = students.find((s: any) => s.email?.toLowerCase() === userEmail);
-        const status = studentRecord ? studentRecord.attendance : 'absent';
+        const status = studentRecord ? studentRecord.attendance : "absent";
         const duration = studentRecord?.duration ?? 0;
+
+        const dt = new Date(cls.startTime);
+        const sessionDate = !isNaN(dt.getTime()) ? dt.toISOString().split("T")[0] : null;
+        const sessionTime = !isNaN(dt.getTime()) ? dt.toISOString().split("T")[1].slice(0,5) : null;
+
         return {
           id: Number(cls.id),
           title: cls.title,
           startTime: cls.startTime,
           endTime: cls.endTime,
+          sessionDate,
+          sessionTime,
           attendanceStatus: status,
           duration,
         };

--- a/src/controller/student/student.service.ts
+++ b/src/controller/student/student.service.ts
@@ -697,6 +697,8 @@ export class StudentService {
       const paginatedClasses = limit ? allSessions.slice(offset, offset + limit) : allSessions;
       const allMeetingIds = allSessions.map((cls) => cls.meetingId);
 
+      const batchName = (allSessions[0] as any)?.batches?.name || null;
+
       const attendanceRecords = allMeetingIds.length
         ? await db
             .select({ meetingId: zuvyStudentAttendance.meetingId, attendance: zuvyStudentAttendance.attendance })
@@ -726,14 +728,11 @@ export class StudentService {
         const studentRecord = students.find((s: any) => s.email?.toLowerCase() === userEmail);
         const status = studentRecord ? studentRecord.attendance : 'absent';
         const duration = studentRecord?.duration ?? 0;
-        const { batches, ...rest } = cls as any;
         return {
-          id: Number(rest.id),
-          title: rest.title,
-          startTime: rest.startTime,
-          endTime: rest.endTime,
-          batchId: Number(rest.batchId),
-          batchName: batches?.name || null,
+          id: Number(cls.id),
+          title: cls.title,
+          startTime: cls.startTime,
+          endTime: cls.endTime,
           attendanceStatus: status,
           duration,
         };
@@ -758,6 +757,8 @@ export class StudentService {
           message: 'Completed classes fetched successfully',
           statusCode: STATUS_CODES.OK,
           data: {
+            batchId,
+            batchName,
             classes: result,
             totalClasses,
             totalPages: limit ? Math.ceil(totalClasses / limit) : 1,

--- a/src/controller/student/student.service.ts
+++ b/src/controller/student/student.service.ts
@@ -725,6 +725,7 @@ export class StudentService {
         const students = attendanceMap.get(cls.meetingId) || [];
         const studentRecord = students.find((s: any) => s.email?.toLowerCase() === userEmail);
         const status = studentRecord ? studentRecord.attendance : 'absent';
+        const duration = studentRecord?.duration ?? 0;
         const { batches, ...rest } = cls as any;
         return {
           id: Number(rest.id),
@@ -734,6 +735,7 @@ export class StudentService {
           batchId: Number(rest.batchId),
           batchName: batches?.name || null,
           attendanceStatus: status,
+          duration,
         };
       });
 


### PR DESCRIPTION
## Summary
- expose new API endpoint to fetch completed classes with attendance status
- implement service method to gather session details and attendance
- compute attendance stats for present/absent counts and percentage

## Testing
- `npm run build`
- `npm test` *(fails: Directory libs in the roots[1] option was not found)*

------
https://chatgpt.com/codex/tasks/task_b_68516c05b0b88333b525d2ef953ee299