### PR TITLE
Add session date/time to completed classes attendance

### DIFF
--- a/src/controller/student/student.controller.ts
+++ b/src/controller/student/student.controller.ts
@@ -181,6 +181,47 @@ export class StudentController {
     return await this.studentService.getAttendanceClass(req.user[0].id);
   }
 
+  @Get('/bootcamp/:bootcampId/completed-classes')
+  @ApiOperation({ summary: 'Get completed classes with attendance for a bootcamp' })
+  @ApiBearerAuth()
+  @ApiQuery({
+    name: 'limit',
+    type: Number,
+    description: 'Number of items per page',
+    required: false
+  })
+  @ApiQuery({
+    name: 'offset',
+    type: Number,
+    description: 'Offset for pagination',
+    required: false
+  })
+  async getCompletedClassesWithAttendance(
+    @Req() req,
+    @Param('bootcampId') bootcampId: number,
+    @Query('limit') limit: number,
+    @Query('offset') offset: number,
+    @Res() res: Response
+  ) {
+    try {
+      const parsedLimit = limit ? Number(limit) : 10;
+      const parsedOffset = offset ? Number(offset) : 0;
+      const [err, success] = await this.studentService.getCompletedClassesWithAttendance(
+        req.user[0].id,
+        bootcampId,
+        parsedLimit,
+        parsedOffset,
+      );
+      if (err) {
+        return ErrorResponse.BadRequestException(err.message).send(res);
+      }
+      const result: any = success;
+      return new SuccessResponse(result.message, result.statusCode, result.data).send(res);
+    } catch (error) {
+      return ErrorResponse.BadRequestException(error.message).send(res);
+    }
+  }
+
 
   @Get('/leaderboard/:bootcampId')
   @ApiOperation({ summary: 'Get the leaderboard of a course' })


### PR DESCRIPTION
## Summary
- include session date and time when mapping completed classes attendance
- create DTO to accept multiple session ids for creating live class chapter
- add content service method to create a single live class chapter and attach sessions
- expose new endpoint `/Content/live-class-chapter` for admins
- make separate chapter creation for each session sent
- remove bulk live class chapter endpoint

## Testing
- `npm run build`
- `npm test` *(fails: Directory libs in the roots[1] option was not found)*

------
https://chatgpt.com/codex/tasks/task_b_68516c05b0b88333b525d2ef953ee299