### PR TITLE
Add description field for bootcamps

### DIFF
--- a/src/controller/bootcamp/dto/bootcamp.dto.ts
+++ b/src/controller/bootcamp/dto/bootcamp.dto.ts
@@ -20,6 +20,15 @@ export class CreateBootcampDto {
   @IsOptional()
   @IsString()
   collaborator?: string;
+
+  @ApiProperty({
+    type: String,
+    example: 'Bootcamp description',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  description?: string;
 }
 
 
@@ -40,6 +49,24 @@ export class EditBootcampDto {
   @IsNotEmpty({ message: 'name is required' })
   @IsString()
   name: string;
+
+  @ApiProperty({
+    type: String,
+    example: 'Bootcamp description',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @ApiProperty({
+    type: String,
+    example: 'Collaboration Name or https://example.com/logo.png',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  collaborator?: string;
 
   @ApiProperty({
     type: String,
@@ -117,6 +144,22 @@ export class PatchBootcampDto {
   @IsString()
   @IsOptional()
   name: string;
+
+  @ApiProperty({
+    type: String,
+    example: 'Bootcamp description',
+  })
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @ApiProperty({
+    type: String,
+    example: 'Collaboration Name or https://example.com/logo.png',
+  })
+  @IsOptional()
+  @IsString()
+  collaborator?: string;
 
   @ApiProperty({
     type: String,


### PR DESCRIPTION
## Summary
- allow description in bootcamp DTOs
- keep schema with description column
- revert migration SQL and meta changes

## Testing
- `npm test` *(fails: Directory libs not found)*
- `npm run migration:generate` *(fails: malformed JSON)*

------
https://chatgpt.com/codex/tasks/task_b_6853a605b48c83338fa3465c7f612da6