### PR TITLE
Add AI duplicate check for coding questions

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -47,3 +47,5 @@ S3_BUCKET_NAME = ""
 RAPID_API_KEY = ""
 RAPID_HOST = "judge0-ce.p.rapidapi.com"
 RAPID_BASE_URL = "https://judge0-ce.p.rapidapi.com"
+# OpenAI API key
+OPENAI_API_KEY=""

--- a/src/helpers/ai.ts
+++ b/src/helpers/ai.ts
@@ -1,0 +1,25 @@
+import axios from 'axios';
+
+export async function generateEmbedding(text: string): Promise<number[] | null> {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) return null;
+  try {
+    const response = await axios.post(
+      'https://api.openai.com/v1/embeddings',
+      { input: text, model: 'text-embedding-ada-002' },
+      { headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${apiKey}` } },
+    );
+    const embedding = response.data?.data?.[0]?.embedding;
+    return embedding || null;
+  } catch (error: any) {
+    console.error('OpenAI embedding error', error?.message || error);
+    return null;
+  }
+}
+
+export function cosineSimilarity(a: number[], b: number[]): number {
+  const dot = a.reduce((sum, val, i) => sum + val * b[i], 0);
+  const magA = Math.sqrt(a.reduce((sum, val) => sum + val * val, 0));
+  const magB = Math.sqrt(b.reduce((sum, val) => sum + val * val, 0));
+  return dot / (magA * magB);
+}


### PR DESCRIPTION
## Summary
- add optional OpenAI API key in sample env
- create `ai` helper with OpenAI embedding and cosine similarity helpers
- use similarity check in `createCodingQuestion` to avoid duplicate questions

## Testing
- `npm test` *(fails: Directory libs missing)*

------
https://chatgpt.com/codex/tasks/task_b_6854ede88528833381b4b86e9679832c