### PR TITLE
Feature/zoom attendance recordings split

### DIFF
--- a/src/services/zoom/zoom.controller.ts
+++ b/src/services/zoom/zoom.controller.ts
@@ -133,7 +133,19 @@ export class ZoomController {
     const ids = meetingIdParam.includes(',')
       ? meetingIdParam.split(',').map(s => s.trim()).filter(Boolean)
       : meetingIdParam;
-    return this.zoomService.computeAttendanceAndRecordings75(ids as any);
+    // Attendance-only
+    return this.zoomService.computeAttendance75(ids as any);
+  }
+
+  @Get('meetings/:id/recordings')
+  @Roles('admin')
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({ summary: 'Fetch recording share links for one or multiple Zoom meetings (comma-separated IDs)' })
+  async recordings(@Param('id') meetingIdParam: string) {
+    const ids = meetingIdParam.includes(',')
+      ? meetingIdParam.split(',').map(s => s.trim()).filter(Boolean)
+      : meetingIdParam;
+    return this.zoomService.getMeetingRecordingsBatch(ids as any);
   }
 
   @Get('meetings/:id/recording-link')


### PR DESCRIPTION
### Summary

**Changes Made:**

* Split Zoom computation into two separate functions:

  * **Attendance-only** (75% rule).
  * **Recordings-only** (fetch + store links).
* Added two API endpoints:

  * `/meetings/:id/attendance-75`
  * `/meetings/:id/recordings`
* Refactored cron into a single orchestrator running every 6 hours:

  * Backfills attendance only for sessions missing aggregated records.
  * Fetches/stores recording links only where `s3link` is null or `not found`.
* Preserved backwards compatibility via wrapper `computeAttendanceAndRecordings75`.

---

### Why

* Improves clarity by separating responsibilities.
* Reduces redundant DB writes.
* Easier debugging and monitoring of attendance vs. recordings.

---

### Next Steps

* Add dev-only admin endpoint for manual trigger.
* Add tests for missing attendance insertion and `s3link` update.
* Add logging/metrics for observability.
