### PR TITLE
remove submissions default limit and offset

### DIFF
--- a/src/controller/adminAssessment/adminAssessment.controller.ts
+++ b/src/controller/adminAssessment/adminAssessment.controller.ts
@@ -147,7 +147,7 @@ export class AdminAssessmentController {
       req,
       assessmentID,
       searchStudent,
-      Number(limit) || 10,
+      limit ? Number(limit) : undefined,
       Number(offset) || 0,
       batchId ? Number(batchId) : undefined,
       qualified,

--- a/src/controller/adminAssessment/adminAssessment.service.ts
+++ b/src/controller/adminAssessment/adminAssessment.service.ts
@@ -681,7 +681,7 @@ Team Zuvy`;
     req,
     assessmentID: number,
     searchStudent: string,
-    limit: number = 10,
+    limit?: number,
     offset: number = 0,
     batchId?: number,
     qualified?: string,
@@ -1010,7 +1010,7 @@ Team Zuvy`;
       const limitNumFinal =
         Number.isFinite(Number(limit)) && Number(limit) > 0
           ? Number(limit)
-          : totalCount || 10;
+          : totalCount;
       const paginatedData = combinedData.slice(
         offsetNumFinal,
         offsetNumFinal + limitNumFinal,


### PR DESCRIPTION
I tested all the APIs in the submission API module, and among them, only the API used in the Assessment tab had a default limit and offset of 10. I have removed that default limit and offset.