### PR TITLE
Chore/org admin

### DIFF
--- a/drizzle/0002_tired_quasimodo.sql
+++ b/drizzle/0002_tired_quasimodo.sql
@@ -565,3 +565,7 @@ CREATE INDEX "zuvy_user_organizations_organization_id_idx"
 
 CREATE INDEX "zuvy_user_organizations_joined_at_idx"
     ON "zuvy_user_organizations" ("joined_at");
+
+ALTER TABLE "zuvy_permissions_roles" 
+ADD COLUMN IF NOT EXISTS "org_id" INTEGER NOT NULL 
+REFERENCES "zuvy_organizations"("id") DEFAULT 1;

--- a/drizzle/0006_org_scoped_roles.sql
+++ b/drizzle/0006_org_scoped_roles.sql
@@ -1,0 +1,12 @@
+ALTER TABLE "zuvy_user_roles"
+DROP CONSTRAINT IF EXISTS "zuvy_user_roles_name_unique";
+
+ALTER TABLE "zuvy_user_roles" 
+DROP CONSTRAINT IF EXISTS "uniq_name";
+
+ALTER TABLE "zuvy_user_roles" 
+DROP CONSTRAINT IF EXISTS "zuvy_user_roles_name_key";
+
+
+ALTER TABLE "zuvy_user_roles" 
+DROP CONSTRAINT IF EXISTS "ZUVY_USER_ROLES_NAME_UNIQUE";

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -3723,9 +3723,12 @@ export const zuvyZoomUsers = main.table('zuvy_zoom_users', {
 // RBAC: Roles Table
 export const zuvyUserRoles = main.table('zuvy_user_roles', {
   id: serial('id').primaryKey().notNull(),
-  name: varchar('name', { length: 50 }).notNull().unique(), // e.g. 'admin', 'instructor', 'ops'
+  name: varchar('name', { length: 50 }).notNull(), // e.g. 'admin', 'instructor', 'ops'
   description: text('description'),
-  orgId: integer('org_id').notNull().references(() => zuvyOrganizations.id),
+  orgId: integer('org_id').notNull().references(() => zuvyOrganizations.id,  {
+    onUpdate: 'cascade',
+    onDelete: 'cascade'
+  }),
 });
 
 export const zuvyResources = main.table('zuvy_resources', {
@@ -3733,7 +3736,6 @@ export const zuvyResources = main.table('zuvy_resources', {
   key: varchar('key', { length: 64 }).notNull().unique(),
   name: varchar('display_name', { length: 100 }).notNull(),
   description: text('description'),
-  orgId: integer('org_id').notNull().references(() => zuvyOrganizations.id),
   createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
   updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow(),
 });
@@ -3750,6 +3752,7 @@ export const zuvyPermissionsRoles = main.table('zuvy_permissions_roles', {
   id: serial('id').primaryKey().notNull(),
   permissionId: integer('permission_id').notNull().references(() => zuvyPermissions.id),
   roleId: integer('role_id').notNull().references(() => zuvyUserRoles.id),
+  orgId: integer('org_id').references(() => zuvyOrganizations.id),
   createdAt: timestamp('created_at', { withTimezone: true, mode: 'string' }).defaultNow(),
   updatedAt: timestamp('updated_at', { withTimezone: true, mode: 'string' }).defaultNow(),
 },

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -501,11 +501,11 @@ export class AuthService {
     // Verify membership
     const [membership] = await db
       .select()
-      .from(zuvyUserOrganizations)
+      .from(zuvyUserRolesAssigned)
       .where(
         and(
-          eq(zuvyUserOrganizations.userId, Number(userId)),
-          eq(zuvyUserOrganizations.organizationId, targetOrgId),
+          eq(zuvyUserRolesAssigned.userId, userId),
+          eq(zuvyUserRolesAssigned.organizationId, targetOrgId),
         ),
       );
 
@@ -539,6 +539,9 @@ export class AuthService {
     await db
       .update(zuvyUserOrganizations)
       .set({
+        userId: Number(userId),
+        organizationId: targetOrgId,
+        userEmail: user.email,
         accessToken: access_token,
         refreshToken: refresh_token,
       } as any)

--- a/src/controller/adminAssessment/adminAssessment.controller.ts
+++ b/src/controller/adminAssessment/adminAssessment.controller.ts
@@ -75,12 +75,14 @@ export class AdminAssessmentController {
     @Query('orderDirection') orderDirection: 'asc' | 'desc',
   ) {
     const roleName = req.user[0]?.roles;
+    const orgId = req.user[0]?.orgId;
     return this.adminAssessmentService.getBootcampAssessment(
       roleName,
       bootcampID,
       searchAssessment,
       orderBy,
       orderDirection,
+      orgId,
     );
   }
 
@@ -241,6 +243,7 @@ export class AdminAssessmentController {
     @Req() req,
   ) {
     const roleName = req.user[0]?.roles;
+    const orgId = req.user[0]?.orgId;
     return this.adminAssessmentService.getBootcampModuleCompletion(
       roleName,
       bootcampID,
@@ -249,6 +252,7 @@ export class AdminAssessmentController {
       offSet,
       orderBy,
       orderDirection,
+      orgId,
     );
   }
 

--- a/src/controller/adminAssessment/adminAssessment.service.ts
+++ b/src/controller/adminAssessment/adminAssessment.service.ts
@@ -533,6 +533,7 @@ Team Zuvy`;
     searchAssessment: string,
     orderBy: 'title',
     orderDirection: 'asc' | 'desc',
+    orgId?: number,
   ) {
     try {
       // ⭐ ERROR HANDLING BLOCK
@@ -667,7 +668,11 @@ Team Zuvy`;
         ResourceList.submission.re_attempt,
       ];
 
-      const perm = await this.rbacService.getAllPermissions(roleName, allowed);
+      const perm = await this.rbacService.getAllPermissions(
+        roleName,
+        allowed,
+        orgId,
+      );
       result['permissions'] = perm.permissions;
 
       return result;
@@ -1344,6 +1349,7 @@ Team Zuvy`;
     offSet?: number,
     orderBy?: 'title',
     orderDirection?: 'asc' | 'desc',
+    orgId?: number,
   ) {
     try {
       // Validate ordering inputs
@@ -1496,6 +1502,7 @@ Team Zuvy`;
       const grantedPermissions = await this.rbacService.getAllPermissions(
         roleName,
         targetPermissions,
+        orgId,
       );
 
       return {

--- a/src/controller/bootcamp/bootcamp.controller.ts
+++ b/src/controller/bootcamp/bootcamp.controller.ts
@@ -92,6 +92,7 @@ export class BootcampController {
       : undefined;
     const roleName = req.user[0]?.roles;
     const userId = req.user[0]?.id;
+    const orgId = req.user[0]?.orgId;
     const [err, res] = await this.bootcampService.getAllBootcamps(
       roleName,
       userId,
@@ -100,6 +101,7 @@ export class BootcampController {
       searchTermAsNumber,
       searchTermAsString,
       organization_id,
+      orgId,
     );
 
     if (err) {
@@ -123,10 +125,12 @@ export class BootcampController {
     @Req() req,
   ): Promise<object> {
     const roleName = req.user[0]?.roles;
+    const orgId = req.user[0]?.orgId;
     const [err, res] = await this.bootcampService.getBootcampById(
       id,
       isContent,
       roleName,
+      orgId,
     );
     if (err) {
       throw new BadRequestException(err);
@@ -155,10 +159,12 @@ export class BootcampController {
     @Req() req,
   ) {
     const roleName = req.user[0]?.roles;
+    const orgId = req.user[0]?.orgId;
     const [err, res] = await this.bootcampService.updateBootcampSetting(
       bootcampId,
       bootcampSetting,
       roleName,
+      orgId,
     );
     if (err) {
       throw new BadRequestException(err);
@@ -174,9 +180,11 @@ export class BootcampController {
     @Req() req,
   ): Promise<object> {
     const roleName = req.user[0]?.roles;
+    const orgId = req.user[0]?.orgId;
     const [err, res] = await this.bootcampService.getBootcampSettingById(
       roleName,
       id,
+      orgId,
     );
     if (err) {
       throw new BadRequestException(err);
@@ -234,11 +242,13 @@ export class BootcampController {
     @Req() req,
   ): Promise<object> {
     const roleName = req.user[0]?.roles;
+    const orgId = req.user[0]?.orgId;
     const [err, res] = await this.bootcampService.getBatchByIdBootcamp(
       bootcamp_id,
       roleName,
       limit,
       offset,
+      orgId,
     );
     if (err) {
       throw new BadRequestException(err);
@@ -302,11 +312,13 @@ export class BootcampController {
     @Req() req,
   ) {
     const roleName = req.user[0]?.roles;
+    const orgId = req.user[0]?.orgId;
     const [err, res] = await this.bootcampService.addStudentToBootcamp(
       bootcamp_id,
       batch_id,
       studentData.students,
       roleName,
+      orgId,
     );
     if (err) {
       throw new BadRequestException(err);
@@ -396,6 +408,7 @@ export class BootcampController {
   ) {
     const roleName = req.user[0]?.roles;
     const userId = req.user[0]?.id;
+    const orgId = req.user[0]?.orgId;
     const searchTermAsNumber = !isNaN(Number(searchTerm))
       ? BigInt(searchTerm)
       : searchTerm;
@@ -435,6 +448,7 @@ export class BootcampController {
       orderBy,
       orderDirection,
       userId,
+      orgId,
     );
     return res;
   }

--- a/src/controller/bootcamp/bootcamp.controller.ts
+++ b/src/controller/bootcamp/bootcamp.controller.ts
@@ -87,6 +87,9 @@ export class BootcampController {
     const searchTermAsNumber = !isNaN(Number(searchTerm))
       ? Number(searchTerm)
       : searchTerm;
+    const searchTermAsString = searchTerm
+      ? String(searchTerm).trim()
+      : undefined;
     const roleName = req.user[0]?.roles;
     const userId = req.user[0]?.id;
     const [err, res] = await this.bootcampService.getAllBootcamps(
@@ -95,6 +98,7 @@ export class BootcampController {
       limit,
       offset,
       searchTermAsNumber,
+      searchTermAsString,
       organization_id,
     );
 

--- a/src/controller/bootcamp/bootcamp.service.ts
+++ b/src/controller/bootcamp/bootcamp.service.ts
@@ -94,6 +94,7 @@ export class BootcampService {
     searchTermAsNumber?: string | number,
     searchTermAsString?: string,
     organization_id?: number,
+    orgId?: number,
   ): Promise<any> {
     try {
       let query;
@@ -255,6 +256,7 @@ export class BootcampService {
       const permissionResult = await this.rbacService.getAllPermissions(
         roleName,
         targetPermissions,
+        orgId,
       );
       allPermissions = permissionResult.permissions || {};
 
@@ -288,6 +290,7 @@ export class BootcampService {
     id: number,
     isContent: boolean,
     role: string[],
+    orgId: number,
   ): Promise<any> {
     try {
       let bootcamp = await db
@@ -313,6 +316,7 @@ export class BootcampService {
       const grantedPermissions = await this.rbacService.getAllPermissions(
         role,
         targetPermissions,
+        orgId,
       );
       return [
         null,
@@ -438,6 +442,7 @@ export class BootcampService {
     bootcamp_id: number,
     settingData,
     roleName: string[],
+    orgId: number,
   ) {
     try {
       const typeOfBootcamp = settingData.type
@@ -457,6 +462,7 @@ export class BootcampService {
       const grantedPermissions = await this.rbacService.getAllPermissions(
         roleName,
         targetPermissions,
+        orgId,
       );
       if (
         typeOfBootcamp == 'Public'.toLowerCase() ||
@@ -507,7 +513,7 @@ export class BootcampService {
     }
   }
 
-  async getBootcampSettingById(roleName, bootcampId: number) {
+  async getBootcampSettingById(roleName, bootcampId: number, orgId: number) {
     try {
       let bootcampSetting = await db
         .select()
@@ -533,6 +539,7 @@ export class BootcampService {
       const grantedPermissions = await this.rbacService.getAllPermissions(
         roleName,
         targetPermissions,
+        orgId,
       );
       return [
         null,
@@ -618,6 +625,7 @@ export class BootcampService {
     roleName: string[],
     limit: number,
     offset: number,
+    orgId: number,
   ): Promise<any> {
     try {
       // sanitize pagination parameters
@@ -714,6 +722,7 @@ export class BootcampService {
       const grantedPermission = await this.rbacService.getAllPermissions(
         roleName,
         targetPermissions,
+        orgId,
       );
       return [
         null,
@@ -805,6 +814,7 @@ export class BootcampService {
     batchId: number,
     users_data: any[],
     roleName: string[],
+    orgId: number,
   ) {
     try {
       var a = 0,
@@ -1078,6 +1088,7 @@ export class BootcampService {
       const grantedPermissions = await this.rbacService.getAllPermissions(
         roleName,
         targetePermission,
+        orgId,
       );
 
       return [
@@ -1127,6 +1138,7 @@ export class BootcampService {
     orderBy?: string,
     orderDirection?: string,
     instructorId?: number, // Add instructor ID parameter
+    orgId?: number,
   ) {
     try {
       const batchIdNum = Number.isFinite(Number(batchId))
@@ -1289,6 +1301,7 @@ export class BootcampService {
         await this.rbacAllocPermsService.getAllPermissions(
           roleName,
           targetPermissions,
+          orgId,
         );
 
       return {
@@ -1562,10 +1575,13 @@ export class BootcampService {
     }
   }
 
-  async getUserPermissionsForMultipleResources(userId: bigint) {
+  async getUserPermissionsForMultipleResources(userId: bigint, orgId: number) {
     try {
       const result =
-        await this.rbacService.getUserPermissionsForMultipleResources(userId);
+        await this.rbacService.getUserPermissionsForMultipleResources(
+          userId,
+          orgId,
+        );
       return [null, result];
     } catch (err) {
       return [err, null];

--- a/src/controller/bootcamp/bootcamp.service.ts
+++ b/src/controller/bootcamp/bootcamp.service.ts
@@ -91,7 +91,8 @@ export class BootcampService {
     userId,
     limit: number,
     offset: number,
-    searchTerm?: string | number,
+    searchTermAsNumber?: string | number,
+    searchTermAsString?: string,
     organization_id?: number,
   ): Promise<any> {
     try {
@@ -130,38 +131,52 @@ export class BootcampService {
         );
       }
 
-      if (searchTerm) {
-        if (typeof searchTerm === 'string') {
-          let searchCondition = sql`LOWER(${zuvyBootcamps.name}) LIKE ${searchTerm.toLowerCase()} || '%'`;
-          if (orgCondition) {
-            searchCondition = and(searchCondition, orgCondition);
-          }
-          query = db
-            .select()
-            .from(zuvyBootcamps)
-            .where(searchCondition)
-            .limit(limit)
-            .offset(offset);
-          countQuery = db
-            .select({ count: count(zuvyBootcamps.id) })
-            .from(zuvyBootcamps)
-            .where(searchCondition);
-        } else {
-          let searchCondition = sql`${zuvyBootcamps.id} = ${searchTerm}`;
-          if (orgCondition) {
-            searchCondition = and(searchCondition, orgCondition);
-          }
-          query = db
-            .select()
-            .from(zuvyBootcamps)
-            .where(searchCondition)
-            .limit(limit)
-            .offset(offset);
-          countQuery = db
-            .select({ count: count(zuvyBootcamps.id) })
-            .from(zuvyBootcamps)
-            .where(searchCondition);
+      const isSearchAsNumber =
+        typeof searchTermAsNumber === 'number' ||
+        (typeof searchTermAsNumber === 'string' &&
+          searchTermAsNumber.trim() !== '' &&
+          !isNaN(Number(searchTermAsNumber)));
+
+      if (isSearchAsNumber) {
+        let searchCondition = sql`${zuvyBootcamps.id} = ${Number(searchTermAsNumber)}`;
+        if (orgCondition) {
+          searchCondition = and(searchCondition, orgCondition);
         }
+        query = db
+          .select()
+          .from(zuvyBootcamps)
+          .where(searchCondition)
+          .orderBy(desc(zuvyBootcamps.updatedAt))
+          .limit(limit)
+          .offset(offset);
+        countQuery = db
+          .select({ count: count(zuvyBootcamps.id) })
+          .from(zuvyBootcamps)
+          .where(searchCondition);
+      } else if (searchTermAsString) {
+        const searchTokens = searchTermAsString.split(/\s+/); // Split by whitespace
+        const searchConditions = searchTokens.map(
+          (token) =>
+            sql`LOWER(${zuvyBootcamps.name}) LIKE ${'%' + token.toLowerCase() + '%'}`,
+        );
+
+        let finalSearchCondition = and(...searchConditions);
+        if (orgCondition) {
+          finalSearchCondition = and(finalSearchCondition, orgCondition);
+        }
+
+        query = db
+          .select()
+          .from(zuvyBootcamps)
+          .where(finalSearchCondition)
+          .orderBy(desc(zuvyBootcamps.updatedAt))
+          .limit(limit)
+          .offset(offset);
+
+        countQuery = db
+          .select({ count: count(zuvyBootcamps.id) })
+          .from(zuvyBootcamps)
+          .where(finalSearchCondition);
       } else if (roleName.includes('instructor')) {
         //first get all batches assigned to the instructor in zuvyBatches table then get all bootcampas from zuvyBootcamps table
         const batches = await db
@@ -194,6 +209,7 @@ export class BootcampService {
           .select()
           .from(zuvyBootcamps)
           .where(condition)
+          .orderBy(desc(zuvyBootcamps.updatedAt))
           .limit(limit)
           .offset(offset);
 
@@ -206,7 +222,10 @@ export class BootcampService {
         if (orgCondition) {
           query = query.where(orgCondition);
         }
-        query = query.limit(limit).offset(offset);
+        query = query
+          .orderBy(desc(zuvyBootcamps.updatedAt))
+          .limit(limit)
+          .offset(offset);
 
         countQuery = db
           .select({ count: count(zuvyBootcamps.id) })

--- a/src/controller/bootcamp/dto/bootcamp.dto.ts
+++ b/src/controller/bootcamp/dto/bootcamp.dto.ts
@@ -47,6 +47,16 @@ export class CreateBootcampDto {
   @IsOptional()
   @IsNumber()
   duration?: number;
+
+  // add the orgId
+  @ApiProperty({
+    type: Number,
+    example: 123,
+    required: true,
+  })
+  @IsNotEmpty()
+  @IsNumber()
+  organizationId: number;
 }
 
 export class EditBootcampDto {

--- a/src/controller/classes/classes.controller.ts
+++ b/src/controller/classes/classes.controller.ts
@@ -42,7 +42,12 @@ import { Public } from '../../auth/decorators/public.decorator';
 import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
 import { auth2Client } from '../../auth/google-auth';
 import { db } from '../../db/index';
-import { userTokens, zuvyBatches } from '../../../drizzle/schema';
+import {
+  userTokens,
+  zuvyBatches,
+  zuvyUserOrganizations,
+  zuvyUserRolesAssigned,
+} from '../../../drizzle/schema';
 import { eq, desc, and, sql, ilike } from 'drizzle-orm';
 
 // config user for admin
@@ -94,21 +99,31 @@ export class ClassesController {
       // Parse state to get user info
       const userInfo = JSON.parse(state);
 
+      let accessToken = tokens.access_token;
+      let refreshToken = tokens.refresh_token;
+
+      let userData = {
+        userId: userInfo.id,
+        userEmail: userInfo.email,
+        organizationId: userInfo.orgId,
+        accessToken: tokens.access_token,
+        refreshToken: tokens.refresh_token,
+      };
+
+      let setTokens = {
+        accessToken,
+        refreshToken,
+      };
       // Store tokens in database
       await db
-        .insert(userTokens)
-        .values({
-          userId: userInfo.id,
-          userEmail: userInfo.email,
-          accessToken: tokens.access_token,
-          refreshToken: tokens.refresh_token,
-        })
+        .insert(zuvyUserOrganizations)
+        .values(userData)
         .onConflictDoUpdate({
-          target: [userTokens.userId],
-          set: {
-            accessToken: tokens.access_token,
-            refreshToken: tokens.refresh_token,
-          },
+          target: [
+            zuvyUserOrganizations.userId,
+            zuvyUserOrganizations.organizationId,
+          ],
+          set: setTokens,
         });
 
       return {

--- a/src/controller/content/content.controller.ts
+++ b/src/controller/content/content.controller.ts
@@ -243,9 +243,11 @@ export class ContentController {
   @ApiBearerAuth('JWT-auth')
   async getAllModules(@Param('bootcampId') bootcampId: number, @Req() req) {
     const roleName = req.user[0]?.roles;
+    const orgId = req.user[0]?.orgId;
     const res = await this.contentService.getAllModuleByBootcampId(
       bootcampId,
       roleName,
+      orgId,
     );
     return res;
   }
@@ -258,9 +260,11 @@ export class ContentController {
     @Req() req,
   ) {
     const roleName = req.user[0]?.roles;
+    const orgId = req.user[0]?.orgId;
     const res = await this.contentService.getAllChaptersOfModule(
       roleName,
       moduleId,
+      orgId,
     );
     return res;
   }
@@ -431,8 +435,9 @@ export class ContentController {
     @Query('offset') offSet: number,
     @Req() req,
   ): Promise<object> {
-    const userId = req.user[0]?.id;
     const roleName = req.user[0]?.roles;
+    const userId = req.user[0]?.id;
+    const orgId = req.user[0]?.orgId;
     const res = await this.contentService.getAllQuizQuestions(
       roleName,
       tagId,
@@ -441,6 +446,7 @@ export class ContentController {
       limit,
       offSet,
       userId,
+      orgId,
     );
     return res;
   }
@@ -501,8 +507,9 @@ export class ContentController {
     @Query('offset') offSet: number,
     @Req() req,
   ): Promise<object> {
-    const userId = req.user[0]?.id;
     const roleName = req.user[0]?.roles;
+    const userId = req.user[0]?.id;
+    const orgId = req.user[0]?.orgId;
     const res = await this.contentService.getAllCodingQuestions(
       roleName,
       tagId,
@@ -511,6 +518,7 @@ export class ContentController {
       limit,
       offSet,
       userId,
+      orgId,
     );
     return res;
   }
@@ -629,8 +637,9 @@ export class ContentController {
     @Query('offset') offset: number,
     @Req() req,
   ): Promise<object> {
-    const userId = req.user[0]?.id;
     const roleName = req.user[0]?.roles;
+    const userId = req.user[0]?.id;
+    const orgId = req.user[0]?.orgId;
     const res = await this.contentService.getAllOpenEndedQuestions(
       roleName,
       tagId,
@@ -639,6 +648,7 @@ export class ContentController {
       limit,
       offset,
       userId,
+      orgId,
     );
     return res;
   }

--- a/src/controller/content/content.service.ts
+++ b/src/controller/content/content.service.ts
@@ -564,7 +564,11 @@ export class ContentService {
     }
   }
 
-  async getAllModuleByBootcampId(bootcampId: number, roleName: string[]) {
+  async getAllModuleByBootcampId(
+    bootcampId: number,
+    roleName: string[],
+    orgId?: number,
+  ) {
     const bootcampInfo = await db
       .select()
       .from(zuvyBootcamps)
@@ -624,6 +628,7 @@ export class ContentService {
       const grantedPermission = await this.rbacService.getAllPermissions(
         roleName,
         targetPermissions,
+        orgId,
       );
       return { modules, ...grantedPermission };
     } catch (err) {
@@ -632,7 +637,7 @@ export class ContentService {
     }
   }
 
-  async getAllChaptersOfModule(roleName, moduleId: number) {
+  async getAllChaptersOfModule(roleName, moduleId: number, orgId?: number) {
     try {
       const module = await db
         .select()
@@ -689,6 +694,7 @@ export class ContentService {
         await this.rbacAllocPermsService.getAllPermissions(
           roleName,
           targetPermissions,
+          orgId,
         );
       return {
         chapterWithTopic,
@@ -2304,6 +2310,7 @@ export class ContentService {
     limit: number,
     offSet: number,
     userId: bigint,
+    orgId?: number,
   ) {
     try {
       const where: SQL[] = [];
@@ -2389,6 +2396,7 @@ export class ContentService {
         const permissionsResult = await this.rbacService.getAllPermissions(
           roleName,
           targetPermissions,
+          orgId,
         );
         userPermissions = permissionsResult;
       } catch (permissionError) {
@@ -2419,6 +2427,7 @@ export class ContentService {
     limit: number,
     offSet: number,
     userId: bigint,
+    orgId?: number,
   ) {
     try {
       let conditions = [];
@@ -2520,6 +2529,7 @@ export class ContentService {
         const permissionsResult = await this.rbacService.getAllPermissions(
           roleName,
           targetPermissions,
+          orgId,
         );
         userPermissions = permissionsResult;
       } catch (permissionError) {
@@ -2975,6 +2985,7 @@ export class ContentService {
     limit: number,
     offset: number,
     userId: bigint,
+    orgId?: number,
   ) {
     try {
       let conditions = [];
@@ -3040,6 +3051,7 @@ export class ContentService {
         const permissionsResult = await this.rbacService.getAllPermissions(
           roleName,
           targetPermissions,
+          orgId,
         );
         userPermissions = permissionsResult;
       } catch (permissionError) {

--- a/src/controller/submissions/submission.controller.ts
+++ b/src/controller/submissions/submission.controller.ts
@@ -89,15 +89,18 @@ export class SubmissionController {
     @Query('searchStudent') searchStudent?: string,
     @Req() req?: any,
   ) {
-    let roleName = req?.user[0]?.roles;
-    return this.submissionService.getSubmissionOfPractiseProblem(
+    const roleName = req.user[0]?.roles;
+    const orgId = req.user[0]?.orgId;
+    const resData = await this.submissionService.getSubmissionOfPractiseProblem(
       roleName,
       bootcampId,
       searchProblem,
-      orderBy as any,
-      orderDirection as any,
+      orderBy,
+      orderDirection,
       searchStudent,
+      orgId,
     );
+    return resData;
   }
 
   @Get('/practiseProblemStatus/:moduleId')
@@ -306,14 +309,19 @@ export class SubmissionController {
     @Query('orderDirection') orderDirection?: 'asc' | 'desc',
     @Req() req?: any,
   ) {
-    const roleName = req?.user?.[0]?.roles;
-    return this.submissionService.getAllProjectSubmissions(
+    const roleName = req.user[0]?.roles;
+    const orgId = req.user[0]?.orgId;
+    const resData = await this.submissionService.getAllProjectSubmissions(
       roleName,
       bootcampId,
       projectName,
       orderBy as any,
       orderDirection as any,
+      undefined,
+      undefined,
+      orgId,
     );
+    return resData;
   }
 
   @Get('/projects/students')
@@ -490,8 +498,8 @@ export class SubmissionController {
   ) {
     try {
       const roleName = req.user[0]?.roles;
-
-      const result = await this.submissionService.getSubmissionOfForms(
+      const orgId = req.user[0]?.orgId;
+      const resValue = await this.submissionService.getSubmissionOfForms(
         roleName,
         bootcampId,
         searchForm,
@@ -499,9 +507,10 @@ export class SubmissionController {
         offset,
         orderBy,
         orderDirection,
+        orgId,
       );
 
-      return result;
+      return resValue;
     } catch (error) {
       return {
         status: 'error',
@@ -628,6 +637,7 @@ export class SubmissionController {
   ) {
     try {
       const roleName = req.user[0]?.roles;
+      const orgId = req.user[0]?.orgId;
       let [err, success] =
         await this.submissionService.getSubmissionOfAssignment(
           roleName,
@@ -635,6 +645,7 @@ export class SubmissionController {
           assignmentName,
           orderBy,
           orderDirection,
+          orgId,
         );
       if (err) {
         return ErrorResponse.BadRequestException(
@@ -877,6 +888,7 @@ export class SubmissionController {
     try {
       // Service should return: { trackingData: [...], totalStudents: N }
       const roleName = req.user[0]?.roles;
+      const orgId = req.user[0]?.orgId;
       const [err, result] =
         await this.submissionService.getLiveChapterSubmissions(
           roleName,
@@ -886,6 +898,7 @@ export class SubmissionController {
           offset,
           orderBy,
           orderDirection,
+          orgId,
         );
       if (err) {
         return ErrorResponse.BadRequestException(

--- a/src/controller/submissions/submission.service.ts
+++ b/src/controller/submissions/submission.service.ts
@@ -66,6 +66,7 @@ export class SubmissionService {
     orderBy?: 'title',
     orderDirection?: 'asc' | 'desc',
     searchTerm?: string,
+    orgId?: number,
   ) {
     try {
       const topicId = 3;
@@ -201,6 +202,7 @@ export class SubmissionService {
       const grantedPermissions = await this.rbacService.getAllPermissions(
         roleName,
         targetPermissions,
+        orgId,
       );
       return {
         status: 'success',
@@ -920,6 +922,7 @@ export class SubmissionService {
     orderDirection?: 'asc' | 'desc',
     submittedDateStart?: string,
     submittedDateEnd?: string,
+    orgId?: number,
   ) {
     try {
       // ===== DATE FILTER =====
@@ -1029,6 +1032,7 @@ export class SubmissionService {
       const grantedPermissions = await this.rbacService.getAllPermissions(
         roleName,
         targetPermissions,
+        orgId,
       );
 
       // ===== RESPONSE =====
@@ -1644,6 +1648,7 @@ export class SubmissionService {
     offset?: number,
     orderBy?: 'title',
     orderDirection?: 'asc' | 'desc',
+    orgId?: number,
   ) {
     try {
       const topicId = 7;
@@ -1746,6 +1751,7 @@ export class SubmissionService {
       const grantedPermissions = await this.rbacService.getAllPermissions(
         roleName,
         targetPermissions,
+        orgId,
       );
 
       return {
@@ -2107,6 +2113,7 @@ export class SubmissionService {
     assignmentName: string,
     orderBy?: 'title',
     orderDirection?: 'asc' | 'desc',
+    orgId?: number,
   ): Promise<any> {
     try {
       const topicId = 5;
@@ -2219,6 +2226,7 @@ export class SubmissionService {
       const grantedPermissions = await this.rbacService.getAllPermissions(
         roleName,
         targetPermissions,
+        orgId,
       );
 
       return [
@@ -2946,6 +2954,7 @@ Zuvy LMS Team
     offset?: number,
     orderBy?: 'title',
     orderDirection?: 'asc' | 'desc',
+    orgId?: number,
   ): Promise<[any, any]> {
     try {
       // Validate ordering inputs
@@ -3062,6 +3071,7 @@ Zuvy LMS Team
       const grantedPermissions = await this.rbacService.getAllPermissions(
         roleName,
         targetPermissions,
+        orgId,
       );
       return [
         null,

--- a/src/controller/users/users.controller.ts
+++ b/src/controller/users/users.controller.ts
@@ -328,12 +328,14 @@ export class UsersController {
     }
 
     const roleName = req.user[0]?.roles;
+    const orgId = req.user[0]?.orgId;
     return this.usersService.getAllUsersWithRoles(
       roleName,
       limitNum,
       offsetNum,
       searchTerm || '', // Default to empty string if undefined
       roleId,
+      orgId,
     );
   }
 

--- a/src/controller/users/users.service.ts
+++ b/src/controller/users/users.service.ts
@@ -552,6 +552,7 @@ export class UsersService {
     offset: number,
     searchTerm: string = '',
     roleId?: number | number[],
+    orgId?: number,
   ): Promise<any> {
     try {
       const search = `%${searchTerm}%`;
@@ -579,6 +580,13 @@ export class UsersService {
             eq(zuvyUserRolesAssigned.roleId, roleId),
           );
         }
+      }
+
+      if (orgId) {
+        finalCondition = and(
+          finalCondition,
+          eq(zuvyUserRolesAssigned.organizationId, orgId),
+        );
       }
 
       // 1. Query for filtered users
@@ -627,6 +635,7 @@ export class UsersService {
       const permissionsResult = await this.rbacService.getAllPermissions(
         roleName,
         targetPermissions,
+        orgId,
       );
 
       return {

--- a/src/guards/roles.guard.ts
+++ b/src/guards/roles.guard.ts
@@ -6,19 +6,27 @@ export class RolesGuard implements CanActivate {
   constructor(private reflector: Reflector) {}
 
   canActivate(context: ExecutionContext): boolean {
-    const requiredRoles = this.reflector.get<string[]>('roles', context.getHandler());
+    const requiredRoles = this.reflector.get<string[]>(
+      'roles',
+      context.getHandler(),
+    );
     if (!requiredRoles) {
       return true;
     }
 
     const { user } = context.switchToHttp().getRequest();
-    
+
     // If user has no roles array, they are a student
     if (!user.roles) {
       return false;
     }
 
+    // Super Admin bypass
+    if (user.roles.includes('super_admin')) {
+      return true;
+    }
+
     // Check if user has any of the required roles
-    return requiredRoles.some(role => user.roles.includes(role));
+    return requiredRoles.some((role) => user.roles.includes(role));
   }
 }

--- a/src/notification/email/providers/ses.provider.ts
+++ b/src/notification/email/providers/ses.provider.ts
@@ -8,8 +8,8 @@ export class SesProvider {
   constructor() {
     // Configure AWS SDK
     AWS.config.update({
-      accessKeyId: process.env.AWS_ACCESS_KEY_ID,
-      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+      accessKeyId: process.env.AWS_SUPPORT_ACCESS_KEY_ID,
+      secretAccessKey: process.env.AWS_SUPPORT_ACCESS_SECRET_KEY,
       region: process.env.AWS_REGION,
     });
 
@@ -29,7 +29,7 @@ export class SesProvider {
     const info = await this.transporter.sendMail({
       from:
         config?.from ||
-        process.env.SES_FROM_EMAIL ||
+        process.env.SUPPORT_EMAIL ||
         '"Zuvy Support" <team@zuvy.org>',
       to,
       subject,

--- a/src/org/org.service.ts
+++ b/src/org/org.service.ts
@@ -40,12 +40,12 @@ export class OrgService {
       const createOrgDtoValues = {
         title: createOrgDto.title,
         displayName: createOrgDto.displayName,
-        logoUrl: createOrgDto.logoUrl,
+        logoUrl: createOrgDto.logoUrl || null,
         pocName: createOrgDto.pocName,
         pocEmail: createOrgDto.pocEmail,
         isManagedByZuvy: createOrgDto.isManagedByZuvy,
-        zuvyPocName: createOrgDto.zuvyPocName,
-        zuvyPocEmail: createOrgDto.zuvyPocEmail,
+        zuvyPocName: createOrgDto.zuvyPocName || null,
+        zuvyPocEmail: createOrgDto.zuvyPocEmail || null,
       };
 
       const result = await db.transaction(async (tx) => {

--- a/src/org/org.service.ts
+++ b/src/org/org.service.ts
@@ -49,19 +49,7 @@ export class OrgService {
       };
 
       const result = await db.transaction(async (tx) => {
-        // 1. Find Admin Role ID
-        const adminRole = await tx
-          .select()
-          .from(zuvyUserRoles)
-          .where(eq(zuvyUserRoles.name, 'admin'))
-          .limit(1);
-
-        if (!adminRole.length) {
-          throw new InternalServerErrorException("Role 'admin' not found");
-        }
-        const adminRoleId = adminRole[0].id;
-
-        // 2. Create Organization
+        // 1. Create Organization
         const [newOrg] = await tx
           .insert(zuvyOrganizations)
           .values(createOrgDtoValues)
@@ -72,6 +60,18 @@ export class OrgService {
             'Failed to create organization',
           );
         }
+
+        // 2. Create org-scoped admin role
+        let createAdminRoleData = {
+          name: 'admin',
+          description: 'Organization Admin with full permissions',
+          orgId: newOrg.id,
+        };
+        const [adminRole] = await tx
+          .insert(zuvyUserRoles)
+          .values(createAdminRoleData)
+          .returning();
+        const adminRoleId = adminRole.id;
 
         // Helper to get or create user and assign role
         const processUser = async (email: string, name: string) => {
@@ -92,7 +92,7 @@ export class OrgService {
             userId = newUser.id;
           }
 
-          // Assign Admin Role if not already assigned
+          // Assign Admin Role if not already assigned for this org
           const [existingRole] = await tx
             .select()
             .from(zuvyUserRolesAssigned)
@@ -100,6 +100,7 @@ export class OrgService {
               and(
                 eq(zuvyUserRolesAssigned.userId, userId),
                 eq(zuvyUserRolesAssigned.roleId, adminRoleId),
+                eq(zuvyUserRolesAssigned.organizationId, newOrg.id),
               ),
             )
             .limit(1);

--- a/src/permissions/permissions.alloc.service.ts
+++ b/src/permissions/permissions.alloc.service.ts
@@ -1,79 +1,128 @@
-import { Injectable, InternalServerErrorException, Logger, NotFoundException } from '@nestjs/common';
+import {
+  Injectable,
+  InternalServerErrorException,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
 import { db } from 'src/db/index';
 import { inArray, sql, eq, and } from 'drizzle-orm';
-import { userRoles, zuvyPermissions, zuvyPermissionsRoles, zuvyResources, zuvyRolePermissions, zuvyUserRoles, zuvyUserRolesAssigned } from 'drizzle/schema';
+import {
+  userRoles,
+  zuvyPermissions,
+  zuvyPermissionsRoles,
+  zuvyResources,
+  zuvyUserRoles,
+  zuvyUserRolesAssigned,
+} from 'drizzle/schema';
 import { ResourceList } from 'src/rbac/utility';
 
 @Injectable()
 export class PermissionsAllocationService {
   private readonly logger = new Logger(PermissionsAllocationService.name);
 
-  async getUserPermissionsByResource(userId: bigint, resourceId: number): Promise<any> {
+  async getUserPermissionsByResource(
+    userId: bigint,
+    resourceId: number,
+    orgId: number,
+  ): Promise<any> {
     try {
       // Check if user exists
-      const userCheck = await db.execute(sql`SELECT id FROM main.users WHERE id = ${userId} LIMIT 1`);
+      const userCheck = await db.execute(
+        sql`SELECT id FROM main.users WHERE id = ${userId} LIMIT 1`,
+      );
       if (!(userCheck as any).rows?.length) {
         throw new NotFoundException('User not found');
       }
-      // Get user's role
+      // Get user's role for this org
       const userRoleResult = await db
         .select({ roleId: zuvyUserRolesAssigned.roleId })
         .from(zuvyUserRolesAssigned)
-        .where(eq(zuvyUserRolesAssigned.userId, userId))
+        .where(
+          and(
+            eq(zuvyUserRolesAssigned.userId, userId),
+            eq(zuvyUserRolesAssigned.organizationId, orgId),
+          ),
+        )
         .limit(1);
       if (!userRoleResult.length) {
         // Return empty permissions if user has no role assigned
         return { userId, roleId: null, permissions: {} };
       }
       const userRoleId = userRoleResult[0].roleId;
-      // Get user's permissions
-      const userPermissionsResult = await db.select({
-        permissionName: zuvyPermissions.name,
-        resourceId: zuvyPermissions.resourcesId,
-        resourceName: zuvyResources.name
-      })
-        .from(zuvyRolePermissions)
-        .innerJoin(zuvyPermissions, eq(zuvyRolePermissions.permissionId, zuvyPermissions.id))
-        .innerJoin(zuvyResources, eq(zuvyPermissions.resourcesId, zuvyResources.id))
-        .where(and(
-          eq(zuvyRolePermissions.roleId, userRoleId),
-          eq(zuvyPermissions.resourcesId, resourceId)
-        ));
+      // Get user's permissions for this org
+      const userPermissionsResult = await db
+        .select({
+          permissionName: zuvyPermissions.name,
+          resourceId: zuvyPermissions.resourcesId,
+          resourceName: zuvyResources.name,
+        })
+        .from(zuvyPermissionsRoles)
+        .innerJoin(
+          zuvyPermissions,
+          eq(zuvyPermissionsRoles.permissionId, zuvyPermissions.id),
+        )
+        .innerJoin(
+          zuvyResources,
+          eq(zuvyPermissions.resourcesId, zuvyResources.id),
+        )
+        .where(
+          and(
+            eq(zuvyPermissionsRoles.roleId, userRoleId),
+            eq(zuvyPermissionsRoles.orgId, orgId),
+            eq(zuvyPermissions.resourcesId, resourceId),
+          ),
+        );
       const permissions = {};
-      userPermissionsResult.forEach(perm => {
-        const resourceName = perm.resourceName === 'course' ? 'Bootcamp' :
-          perm.resourceName === 'contentBank' ? 'ContentBank' :
-            perm.resourceName;
+      userPermissionsResult.forEach((perm) => {
+        const resourceName =
+          perm.resourceName === 'course'
+            ? 'Bootcamp'
+            : perm.resourceName === 'contentBank'
+              ? 'ContentBank'
+              : perm.resourceName;
         const permissionKey = `${perm.permissionName}${resourceName.charAt(0).toUpperCase() + resourceName.slice(1)}`;
         permissions[permissionKey] = true;
       });
       return {
         userId,
         roleId: userRoleId,
-        permissions
+        permissions,
       };
     } catch (err) {
-      this.logger.error(`Error getting user permissions for user ${userId} and resource ${resourceId}:`, err);
+      this.logger.error(
+        `Error getting user permissions for user ${userId} and resource ${resourceId}:`,
+        err,
+      );
       if (err instanceof NotFoundException) throw err;
-      throw new InternalServerErrorException('Failed to retrieve user permissions');
+      throw new InternalServerErrorException(
+        'Failed to retrieve user permissions',
+      );
     }
   }
 
-  async getUserPermissionsForMultipleResources(userId: bigint): Promise<any> {
+  async getUserPermissionsForMultipleResources(
+    userId: bigint,
+    orgId: number,
+  ): Promise<any> {
     try {
       // Check if user exists
       const userCheck = await db.execute(
-        sql`SELECT id FROM main.users WHERE id = ${userId} LIMIT 1`
+        sql`SELECT id FROM main.users WHERE id = ${userId} LIMIT 1`,
       );
       if (!(userCheck as any).rows?.length) {
         throw new NotFoundException('User not found');
       }
 
-      // Get user's role
+      // Get user's role for this org
       const userRoleResult = await db
         .select({ roleId: zuvyUserRolesAssigned.roleId })
         .from(zuvyUserRolesAssigned)
-        .where(eq(zuvyUserRolesAssigned.userId, userId))
+        .where(
+          and(
+            eq(zuvyUserRolesAssigned.userId, userId),
+            eq(zuvyUserRolesAssigned.organizationId, orgId),
+          ),
+        )
         .limit(1);
 
       if (!userRoleResult.length) {
@@ -82,14 +131,16 @@ export class PermissionsAllocationService {
 
       const userRoleId = userRoleResult[0].roleId;
 
-      // Fetch permissions directly from zuvy_permissions for this role
+      // Fetch permissions directly from zuvy_permissions_roles for this role and org
       const userPermissionsResult = await db.execute(sql`
       SELECT 
         p.name AS "permissionName",
         r.name AS "resourceName"
       FROM main.zuvy_permissions p
       INNER JOIN main.zuvy_resources r ON p.resource_id = r.id
-      WHERE p.role_id = ${userRoleId}
+      INNER JOIN main.zuvy_permissions_roles pr ON p.id = pr.permission_id
+      WHERE pr.role_id = ${userRoleId}
+        AND pr.org_id = ${orgId}
         AND p.resource_id IN (1, 2, 3)
     `);
 
@@ -105,8 +156,7 @@ export class PermissionsAllocationService {
                 ? 'ContentBank'
                 : perm.resourceName;
 
-          const key =
-            `${perm.permissionName}${resourceName.charAt(0).toUpperCase()}${resourceName.slice(1)}`;
+          const key = `${perm.permissionName}${resourceName.charAt(0).toUpperCase()}${resourceName.slice(1)}`;
 
           permissions[key] = true; // only granted permissions
         });
@@ -119,25 +169,36 @@ export class PermissionsAllocationService {
         err,
       );
       if (err instanceof NotFoundException) throw err;
-      throw new InternalServerErrorException('Failed to retrieve user permissions');
+      throw new InternalServerErrorException(
+        'Failed to retrieve user permissions',
+      );
     }
   }
 
-  async checkUserPermission(userId: number, resourceId: number, permissionName: string): Promise<any> {
+  async checkUserPermission(
+    userId: number,
+    resourceId: number,
+    permissionName: string,
+    orgId: number,
+  ): Promise<any> {
     try {
       // First check if user exists
-      const userCheck = await db.execute(sql`SELECT id FROM main.users WHERE id = ${userId} LIMIT 1`);
+      const userCheck = await db.execute(
+        sql`SELECT id FROM main.users WHERE id = ${userId} LIMIT 1`,
+      );
       if (!(userCheck as any).rows?.length) {
         throw new NotFoundException('User not found');
       }
 
       // Check if resource exists
-      const resourceCheck = await db.execute(sql`SELECT id, name FROM main.zuvy_resources WHERE id = ${resourceId} LIMIT 1`);
+      const resourceCheck = await db.execute(
+        sql`SELECT id, name FROM main.zuvy_resources WHERE id = ${resourceId} LIMIT 1`,
+      );
       if (!(resourceCheck as any).rows?.length) {
         throw new NotFoundException('Resource not found');
       }
 
-      // Check role-based permission
+      // Check role-based permission (scoped to org)
       const rolePermission = await db.execute(sql`
         SELECT DISTINCT 
           p.id as permission_id,
@@ -147,10 +208,12 @@ export class PermissionsAllocationService {
           'role_based' as permission_type
         FROM main.zuvy_permissions p
         INNER JOIN main.zuvy_resources r ON p.resources_id = r.id
-        INNER JOIN main.zuvy_role_permissions rp ON p.id = rp.permission_id
-        INNER JOIN main.zuvy_user_roles ur ON rp.role_id = ur.id
+        INNER JOIN main.zuvy_permissions_roles pr ON p.id = pr.permission_id
+        INNER JOIN main.zuvy_user_roles ur ON pr.role_id = ur.id
         INNER JOIN main.zuvy_user_roles_assigned ura ON ura.role_id = ur.id
-        WHERE ura.user_id = ${userId} AND r.id = ${resourceId} AND p.name = ${permissionName}
+        WHERE ura.user_id = ${userId} AND ura.organization_id = ${orgId} 
+          AND pr.org_id = ${orgId}
+          AND r.id = ${resourceId} AND p.name = ${permissionName}
       `);
 
       // Check extra permission
@@ -186,16 +249,19 @@ export class PermissionsAllocationService {
           hasPermission,
           permissionSources: {
             roleBased: hasRolePermission,
-            extra: hasExtraPermission
+            extra: hasExtraPermission,
           },
           details: {
             roleBased: hasRolePermission ? (rolePermission as any).rows : [],
-            extra: hasExtraPermission ? (extraPermission as any).rows : []
-          }
-        }
+            extra: hasExtraPermission ? (extraPermission as any).rows : [],
+          },
+        },
       };
     } catch (err) {
-      this.logger.error(`Error checking permission for user ${userId}, resource ${resourceId}, permission ${permissionName}:`, err);
+      this.logger.error(
+        `Error checking permission for user ${userId}, resource ${resourceId}, permission ${permissionName}:`,
+        err,
+      );
       if (err instanceof NotFoundException) throw err;
       throw new InternalServerErrorException('Failed to check user permission');
     }
@@ -203,7 +269,7 @@ export class PermissionsAllocationService {
 
   async formatPermissionsAndCompare(
     rolePermissions: string[],
-    targetPermissions: string[]
+    targetPermissions: string[],
   ): Promise<Record<string, boolean>> {
     try {
       const permissions: Record<string, boolean> = {};
@@ -220,35 +286,84 @@ export class PermissionsAllocationService {
     }
   }
 
-  async getAllPermissions(roleName: string[], targetPermissions: string[], resourceIds?: number): Promise<any> {
+  async getAllPermissions(
+    roleNames: string[],
+    targetPermissions: string[],
+    orgId: number,
+  ): Promise<any> {
     try {
-      const roleCheck = await db
+      if (!roleNames || roleNames.length === 0) {
+        return {
+          permissions: await this.formatPermissionsAndCompare(
+            [],
+            targetPermissions,
+          ),
+        };
+      }
+
+      const roles = await db
         .select({ id: zuvyUserRoles.id })
         .from(zuvyUserRoles)
-        .where(eq(zuvyUserRoles.name, roleName[0]))
-        .limit(1);
+        .where(
+          and(
+            inArray(zuvyUserRoles.name, roleNames),
+            eq(zuvyUserRoles.orgId, orgId),
+          ),
+        );
 
-      if (!roleCheck.length) {
-        throw new NotFoundException('Role not found');
+      if (!roles.length) {
+        // Log a warning instead of throwing if roles aren't found in this org,
+        // as the user might have roles from other orgs or default roles.
+        this.logger.warn(
+          `No roles found for ${roleNames.join(', ')} in org ${orgId}`,
+        );
+        return {
+          permissions: await this.formatPermissionsAndCompare(
+            [],
+            targetPermissions,
+          ),
+        };
       }
-      const roleId = roleCheck[0].id;
+
+      const roleIds = roles.map((r) => r.id);
 
       const permissionsWithRoles = await db
-      .select({ action: zuvyPermissions.name, key: zuvyResources.key })
-      .from(zuvyPermissions)
-      .innerJoin(zuvyPermissionsRoles, eq(zuvyPermissionsRoles.permissionId, zuvyPermissions.id))
-      .innerJoin(zuvyResources, eq(zuvyPermissions.resourcesId, zuvyResources.id))
-      .where(eq(zuvyPermissionsRoles.roleId, roleId));
+        .select({ action: zuvyPermissions.name, key: zuvyResources.key })
+        .from(zuvyPermissions)
+        .innerJoin(
+          zuvyPermissionsRoles,
+          eq(zuvyPermissionsRoles.permissionId, zuvyPermissions.id),
+        )
+        .innerJoin(
+          zuvyResources,
+          eq(zuvyPermissions.resourcesId, zuvyResources.id),
+        )
+        .where(
+          and(
+            inArray(zuvyPermissionsRoles.roleId, roleIds),
+            eq(zuvyPermissionsRoles.orgId, orgId),
+          ),
+        );
 
-      const assignedPermissions: string[] = permissionsWithRoles.map(r => `${r.action}${r.key}`);
+      const assignedPermissions: string[] = permissionsWithRoles.map(
+        (r) => `${r.action}${r.key}`,
+      );
 
-      const filteredPermissions = await this.formatPermissionsAndCompare(assignedPermissions, targetPermissions)
+      const filteredPermissions = await this.formatPermissionsAndCompare(
+        assignedPermissions,
+        targetPermissions,
+      );
 
       return { permissions: filteredPermissions };
-    }
-    catch (err) {
+    } catch (err) {
       this.logger.error('Error retrieving all permissions:', err);
-      throw new InternalServerErrorException('Failed to retrieve permissions');
+      // If it's already a NestJS exception (like NotFoundException), re-throw it
+      if (err.status && err.getResponse) {
+        throw err;
+      }
+      throw new InternalServerErrorException(
+        'Failed to retrieve permissions: ' + err.message,
+      );
     }
   }
 }

--- a/src/permissions/permissions.controller.ts
+++ b/src/permissions/permissions.controller.ts
@@ -1,9 +1,38 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete, HttpException, HttpStatus, Query, ParseIntPipe, Req } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+  HttpException,
+  HttpStatus,
+  Query,
+  ParseIntPipe,
+  Req,
+} from '@nestjs/common';
 import { PermissionsService } from './permissions.service';
 import { CreatePermissionDto } from './dto/create-permission.dto';
 import { UpdatePermissionDto } from './dto/update-permission.dto';
-import { ApiBearerAuth, ApiBody, ApiNotFoundResponse, ApiOkResponse, ApiOperation, ApiParam, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
-import { AssignPermissionsToRoleDto, AssignPermissionsToUserDto, PermissionAssignmentResponseDto, PermissionResponseDto, UserPermissionResponseDto } from 'src/rbac/dto/permission.dto';
+import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiParam,
+  ApiQuery,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import {
+  AssignPermissionsToRoleDto,
+  AssignPermissionsToUserDto,
+  PermissionAssignmentResponseDto,
+  PermissionResponseDto,
+  UserPermissionResponseDto,
+} from 'src/rbac/dto/permission.dto';
 import { PermissionsAllocationService } from './permissions.alloc.service';
 
 @ApiTags('Permissions')
@@ -11,72 +40,84 @@ import { PermissionsAllocationService } from './permissions.alloc.service';
 export class PermissionsController {
   constructor(
     private readonly permissionsService: PermissionsService,
-    private readonly permissionsAllocationService: PermissionsAllocationService
+    private readonly permissionsAllocationService: PermissionsAllocationService,
   ) {}
 
   @Post()
   //   @RequirePermissions('create_permission')
   @ApiOperation({
     summary: 'Create a new permission',
-    description: 'Adds a new permission with name, resource ID and optional description'
+    description:
+      'Adds a new permission with name, resource ID and optional description',
   })
   @ApiBody({
     type: CreatePermissionDto,
-    description: 'Permission data to create'
+    description: 'Permission data to create',
   })
   @ApiResponse({
     status: 201,
     description: 'Permission created successfully',
-    type: PermissionResponseDto
+    type: PermissionResponseDto,
   })
   @ApiResponse({
     status: 400,
-    description: 'Bad request - Invalid input data or resource not found'
+    description: 'Bad request - Invalid input data or resource not found',
   })
   @ApiResponse({
     status: 500,
-    description: 'Internal server error'
+    description: 'Internal server error',
   })
   @ApiBearerAuth('JWT-auth')
-  async createPermission(@Body() createPermissionDto: CreatePermissionDto): Promise<any> {
+  async createPermission(
+    @Body() createPermissionDto: CreatePermissionDto,
+  ): Promise<any> {
     try {
-      const result = await this.permissionsService.createPermission(createPermissionDto);
+      const result =
+        await this.permissionsService.createPermission(createPermissionDto);
       return result;
     } catch (error) {
       if (error instanceof HttpException) {
         throw error;
       }
       if (error.code === '23505') {
-        throw new HttpException('Permission with this name already exists', HttpStatus.BAD_REQUEST);
+        throw new HttpException(
+          'Permission with this name already exists',
+          HttpStatus.BAD_REQUEST,
+        );
       }
-      throw new HttpException('Internal Server Error', HttpStatus.INTERNAL_SERVER_ERROR);
+      throw new HttpException(
+        'Internal Server Error',
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
     }
   }
 
   @Get()
   @ApiOperation({
     summary: 'Get all permissions',
-    description: 'Retrieves all permissions from the system with pagination, search, and filtering. Optional parameters for resourceId, search, page, and limit.'
+    description:
+      'Retrieves all permissions from the system with pagination, search, and filtering. Optional parameters for resourceId, search, page, and limit.',
   })
   @ApiQuery({
     name: 'resourceId',
     required: false,
     description: 'Optional resource ID to filter permissions by resource',
-    type: Number
+    type: Number,
   })
   @ApiQuery({
     name: 'searchPermission',
     required: false,
-    description: 'Optional search term to filter permissions by name or description',
-    type: String
+    description:
+      'Optional search term to filter permissions by name or description',
+    type: String,
   })
   @ApiResponse({
     status: 200,
-    description: 'Permissions retrieved successfully'
+    description: 'Permissions retrieved successfully',
   })
   @ApiResponse({
     status: 500,
-    description: 'Internal server error'
+    description: 'Internal server error',
   })
   @ApiBearerAuth('JWT-auth')
   async getAllPermissions(
@@ -84,10 +125,16 @@ export class PermissionsController {
     @Query('searchPermission') searchPermission?: string,
   ): Promise<any> {
     try {
-      const result = await this.permissionsService.getAllPermissions(resourceId, searchPermission);
+      const result = await this.permissionsService.getAllPermissions(
+        resourceId,
+        searchPermission,
+      );
       return result;
     } catch (error) {
-      throw new HttpException('Internal Server Error', HttpStatus.INTERNAL_SERVER_ERROR);
+      throw new HttpException(
+        'Internal Server Error',
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
     }
   }
 
@@ -113,41 +160,45 @@ export class PermissionsController {
   //   }
   // }
 
-
   @Post('assign/toRole')
   @ApiOperation({
     summary: 'Assign permissions to role',
-    description: 'Admin can assign specific permissions to a role'
+    description: 'Admin can assign specific permissions to a role',
   })
   @ApiBody({
     type: AssignPermissionsToRoleDto,
-    description: 'Role ID and permissions to assign'
+    description: 'Role ID and permissions to assign',
   })
   @ApiResponse({
     status: 201,
     description: 'Permissions assigned successfully',
-    type: PermissionAssignmentResponseDto
+    type: PermissionAssignmentResponseDto,
   })
   @ApiResponse({
     status: 400,
-    description: 'Bad request - Invalid input data or role not found'
+    description: 'Bad request - Invalid input data or role not found',
   })
   @ApiResponse({
     status: 404,
-    description: 'Role not found'
+    description: 'Role not found',
   })
   @ApiResponse({
     status: 500,
-    description: 'Internal server error'
+    description: 'Internal server error',
   })
   @ApiBearerAuth('JWT-auth')
   async assignPermissionsToRole(
     @Body() assignPermissionsDto: AssignPermissionsToRoleDto,
-    @Req() req
+    @Req() req,
   ): Promise<any> {
     try {
       const userIdString = req.user[0].id;
-      const result = await this.permissionsService.assignPermissionsToRole(userIdString, assignPermissionsDto);
+      const orgId = req.user[0]?.orgId;
+      const result = await this.permissionsService.assignPermissionsToRole(
+        userIdString,
+        assignPermissionsDto,
+        orgId,
+      );
       return result;
     } catch (error) {
       if (error instanceof HttpException) {
@@ -157,42 +208,53 @@ export class PermissionsController {
         throw new HttpException('Role not found', HttpStatus.NOT_FOUND);
       }
       if (error.code === '23505') {
-        throw new HttpException('Permission already assigned to role', HttpStatus.BAD_REQUEST);
+        throw new HttpException(
+          'Permission already assigned to role',
+          HttpStatus.BAD_REQUEST,
+        );
       }
-      throw new HttpException('Internal Server Error', HttpStatus.INTERNAL_SERVER_ERROR);
+      throw new HttpException(
+        'Internal Server Error',
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
     }
   }
 
   @Post('assign/to/user')
   @ApiOperation({
     summary: 'Assign permissions to user',
-    description: 'Admin can assign specific permissions to a user'
+    description: 'Admin can assign specific permissions to a user',
   })
   @ApiBody({
     type: AssignPermissionsToUserDto,
-    description: 'User ID and permissions to assign'
+    description: 'User ID and permissions to assign',
   })
   @ApiResponse({
     status: 201,
     description: 'Permissions assigned successfully',
-    type: PermissionAssignmentResponseDto
+    type: PermissionAssignmentResponseDto,
   })
   @ApiResponse({
     status: 400,
-    description: 'Bad request - Invalid input data or user/role not found'
+    description: 'Bad request - Invalid input data or user/role not found',
   })
   @ApiResponse({
     status: 404,
-    description: 'User or role not found'
+    description: 'User or role not found',
   })
   @ApiResponse({
     status: 500,
-    description: 'Internal server error'
+    description: 'Internal server error',
   })
   @ApiBearerAuth('JWT-auth')
-  async assignPermissionsToUser(@Body() assignPermissionsDto: AssignPermissionsToUserDto): Promise<any> {
+  async assignPermissionsToUser(
+    @Body() assignPermissionsDto: AssignPermissionsToUserDto,
+  ): Promise<any> {
     try {
-      const result = await this.permissionsService.assignPermissionsToUser(assignPermissionsDto);
+      const result =
+        await this.permissionsService.assignPermissionsToUser(
+          assignPermissionsDto,
+        );
       return result;
     } catch (error) {
       if (error instanceof HttpException) {
@@ -202,75 +264,102 @@ export class PermissionsController {
         throw new HttpException('User or role not found', HttpStatus.NOT_FOUND);
       }
       if (error.code === '23505') {
-        throw new HttpException('Permission already assigned to user', HttpStatus.BAD_REQUEST);
+        throw new HttpException(
+          'Permission already assigned to user',
+          HttpStatus.BAD_REQUEST,
+        );
       }
-      throw new HttpException('Internal Server Error', HttpStatus.INTERNAL_SERVER_ERROR);
+      throw new HttpException(
+        'Internal Server Error',
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
     }
   }
 
   @Get('users/:userId/permissions/:resourceId')
   @ApiOperation({
     summary: 'Get user permissions for a specific resource',
-    description: 'Retrieves all permissions (role-based and extra) that a user has for a specific resource'
+    description:
+      'Retrieves all permissions (role-based and extra) that a user has for a specific resource',
   })
   @ApiResponse({
     status: 200,
     description: 'User permissions retrieved successfully',
-    type: UserPermissionResponseDto
+    type: UserPermissionResponseDto,
   })
   @ApiResponse({
     status: 404,
-    description: 'User or resource not found'
+    description: 'User or resource not found',
   })
   @ApiResponse({
     status: 500,
-    description: 'Internal server error'
+    description: 'Internal server error',
   })
   @ApiBearerAuth('JWT-auth')
   async getUserPermissionsByResource(
     @Param('userId', ParseIntPipe) userId: bigint,
-    @Param('resourceId', ParseIntPipe) resourceId: number
+    @Param('resourceId', ParseIntPipe) resourceId: number,
+    @Req() req,
   ): Promise<any> {
     try {
-      const result = await this.permissionsAllocationService.getUserPermissionsByResource(userId, resourceId);
+      const orgId = req.user[0]?.orgId;
+      const result =
+        await this.permissionsAllocationService.getUserPermissionsByResource(
+          userId,
+          resourceId,
+          orgId,
+        );
       return result;
     } catch (error) {
       if (error instanceof HttpException) {
         throw error;
       }
-      throw new HttpException('Internal Server Error', HttpStatus.INTERNAL_SERVER_ERROR);
+      throw new HttpException(
+        'Internal Server Error',
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
     }
   }
 
   @Get('users/:userId/permissions-multiple')
   @ApiOperation({
     summary: 'Get user permissions for multiple resources',
-    description: 'Retrieves permissions for course, contentBank, and roles and permissions resources'
+    description:
+      'Retrieves permissions for course, contentBank, and roles and permissions resources',
   })
   @ApiResponse({
     status: 200,
-    description: 'User permissions retrieved successfully'
+    description: 'User permissions retrieved successfully',
   })
   @ApiResponse({
     status: 404,
-    description: 'User not found'
+    description: 'User not found',
   })
   @ApiResponse({
     status: 500,
-    description: 'Internal server error'
+    description: 'Internal server error',
   })
   @ApiBearerAuth('JWT-auth')
   async getUserPermissionsForMultipleResources(
-    @Param('userId', ParseIntPipe) userId: bigint
+    @Param('userId', ParseIntPipe) userId: bigint,
+    @Req() req,
   ): Promise<any> {
     try {
-      const result = await this.permissionsAllocationService.getUserPermissionsForMultipleResources(userId);
+      const orgId = req.user[0]?.orgId;
+      const result =
+        await this.permissionsAllocationService.getUserPermissionsForMultipleResources(
+          userId,
+          orgId,
+        );
       return result;
     } catch (error) {
       if (error instanceof HttpException) {
         throw error;
       }
-      throw new HttpException('Internal Server Error', HttpStatus.INTERNAL_SERVER_ERROR);
+      throw new HttpException(
+        'Internal Server Error',
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
     }
   }
 
@@ -278,19 +367,19 @@ export class PermissionsController {
   //   @RequirePermissions('delete_permission')
   @ApiOperation({
     summary: 'Delete a permission by id',
-    description: 'Deletes a permission record by its numeric id'
+    description: 'Deletes a permission record by its numeric id',
   })
   @ApiResponse({
     status: 200,
-    description: 'Permission deleted successfully'
+    description: 'Permission deleted successfully',
   })
   @ApiResponse({
     status: 404,
-    description: 'Permission not found'
+    description: 'Permission not found',
   })
   @ApiResponse({
     status: 500,
-    description: 'Internal server error'
+    description: 'Internal server error',
   })
   @ApiBearerAuth('JWT-auth')
   async deletePermission(@Param('id', ParseIntPipe) id: number): Promise<any> {
@@ -301,20 +390,26 @@ export class PermissionsController {
       if (error instanceof HttpException) {
         throw error;
       }
-      throw new HttpException('Internal Server Error', HttpStatus.INTERNAL_SERVER_ERROR);
+      throw new HttpException(
+        'Internal Server Error',
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
     }
   }
 
-    @Get(':roleId/permissions/:resourceId')
-    @ApiOperation({ summary: 'Get permissions for a role and resource' })
-    @ApiParam({ name: 'roleId', example: 1, description: 'Role ID' })
-    @ApiParam({ name: 'resourceId', example: 1, description: 'Resource ID' })
-    @ApiOkResponse({ description: 'Permissions retrieved' })
-    @ApiNotFoundResponse({ description: 'Role or Resource not found' })
-    async getPermissionsByRoleAndResource(
-      @Param('roleId') roleId: number,
-      @Param('resourceId') resourceId: number,
-    ) {
-      return this.permissionsService.getPermissionsByRoleAndResource(+roleId, +resourceId);
-    }
+  @Get(':roleId/permissions/:resourceId')
+  @ApiOperation({ summary: 'Get permissions for a role and resource' })
+  @ApiParam({ name: 'roleId', example: 1, description: 'Role ID' })
+  @ApiParam({ name: 'resourceId', example: 1, description: 'Resource ID' })
+  @ApiOkResponse({ description: 'Permissions retrieved' })
+  @ApiNotFoundResponse({ description: 'Role or Resource not found' })
+  async getPermissionsByRoleAndResource(
+    @Param('roleId') roleId: number,
+    @Param('resourceId') resourceId: number,
+  ) {
+    return this.permissionsService.getPermissionsByRoleAndResource(
+      +roleId,
+      +resourceId,
+    );
+  }
 }

--- a/src/permissions/permissions.service.ts
+++ b/src/permissions/permissions.service.ts
@@ -19,7 +19,6 @@ import {
   zuvyPermissions,
   zuvyResources,
   zuvyPermissionsRoles,
-  zuvyRolePermissions,
   zuvyUserPermissions,
   zuvyUserRoles,
   zuvyUserRolesAssigned,
@@ -206,15 +205,16 @@ export class PermissionsService {
     }
   }
 
-  async getUserPermissions(userId: number): Promise<string[]> {
+  async getUserPermissions(userId: number, orgId: number): Promise<string[]> {
     try {
       const result = await db.execute(sql`
         SELECT DISTINCT p.name 
         FROM main.zuvy_permissions p
-        INNER JOIN main.zuvy_role_permissions rp ON p.id = rp.permission_id
-        INNER JOIN main.zuvy_user_roles ur ON rp.role_id = ur.id
+        INNER JOIN main.zuvy_permissions_roles pr ON p.id = pr.permission_id
+        INNER JOIN main.zuvy_user_roles ur ON pr.role_id = ur.id
         INNER JOIN main.zuvy_user_roles_assigned ura ON ura.role_id = ur.id
-        WHERE ura.user_id = ${userId}
+        WHERE ura.user_id = ${userId} AND ura.organization_id = ${orgId}
+          AND pr.org_id = ${orgId}
       `);
 
       const permissions = (result as any).rows.map((row) => row.name);
@@ -233,13 +233,14 @@ export class PermissionsService {
   async userHasPermissions(
     userId: number,
     requiredPermissions: string[],
+    orgId: number,
   ): Promise<boolean> {
     try {
       if (!requiredPermissions || requiredPermissions.length === 0) {
         return true;
       }
 
-      const userPermissions = await this.getUserPermissions(userId);
+      const userPermissions = await this.getUserPermissions(userId, orgId);
       const hasAllPermissions = requiredPermissions.every((permission) =>
         userPermissions.includes(permission),
       );
@@ -369,7 +370,11 @@ export class PermissionsService {
     }
   }
 
-  async assignPermissionsToRole(userIdString, dto: AssignPermissionsToRoleDto) {
+  async assignPermissionsToRole(
+    userIdString,
+    dto: AssignPermissionsToRoleDto,
+    orgId: number,
+  ) {
     try {
       const { resourceId, roleId, permissions } = dto;
       const actorUserId = Number(userIdString);
@@ -419,7 +424,13 @@ export class PermissionsService {
         if (enableIds.length) {
           await tx
             .insert(zuvyPermissionsRoles)
-            .values(enableIds.map((permissionId) => ({ roleId, permissionId })))
+            .values(
+              enableIds.map((permissionId) => ({
+                roleId,
+                permissionId,
+                orgId,
+              })),
+            )
             .onConflictDoNothing({
               target: [
                 zuvyPermissionsRoles.roleId,

--- a/src/rbac/dto/permission.dto.ts
+++ b/src/rbac/dto/permission.dto.ts
@@ -1,11 +1,20 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { ArrayMinSize, IsArray, IsNotEmpty, IsNotEmptyObject, IsNumber, IsOptional, IsString, ValidateNested } from 'class-validator';
+import {
+  ArrayMinSize,
+  IsArray,
+  IsNotEmpty,
+  IsNotEmptyObject,
+  IsNumber,
+  IsOptional,
+  IsString,
+  ValidateNested,
+} from 'class-validator';
 import { Transform, Type } from 'class-transformer';
 
 export class CreatePermissionDto {
   @ApiProperty({
     description: 'Name of the permission (e.g., view, create, delete)',
-    example: 'view'
+    example: 'view',
   })
   @IsString()
   @IsNotEmpty()
@@ -13,7 +22,7 @@ export class CreatePermissionDto {
 
   @ApiProperty({
     description: 'Resource ID that this permission belongs to',
-    example: 1
+    example: 1,
   })
   @IsNumber()
   @IsNotEmpty()
@@ -22,7 +31,7 @@ export class CreatePermissionDto {
   @ApiProperty({
     description: 'Optional human readable description',
     example: 'Allows viewing course details',
-    required: false
+    required: false,
   })
   @IsString()
   @IsOptional()
@@ -39,28 +48,32 @@ export class PermissionResponseDto {
   @ApiProperty({ description: 'Resource ID', example: 1 })
   resourceId: number;
 
-  @ApiProperty({ description: 'Permission description', example: 'Allows viewing course details', required: false })
+  @ApiProperty({
+    description: 'Permission description',
+    example: 'Allows viewing course details',
+    required: false,
+  })
   description?: string;
 }
 
 export class AssignUserPermissionDto {
   @ApiProperty({
     description: 'Admin (actor) user ID performing the assignment',
-    example: 1
+    example: 1,
   })
   @IsNumber()
   actorUserId: number;
 
   @ApiProperty({
     description: 'Target user ID receiving the extra permission',
-    example: 123
+    example: 123,
   })
   @IsNumber()
   targetUserId: number;
 
   @ApiProperty({
     description: 'Permission ID being assigned to the user',
-    example: 42
+    example: 42,
   })
   @IsNumber()
   permissionId: number;
@@ -68,7 +81,7 @@ export class AssignUserPermissionDto {
   @ApiProperty({
     description: 'Optional scope ID if scoping is used',
     required: false,
-    example: 3
+    example: 3,
   })
   @IsOptional()
   @IsNumber()
@@ -78,14 +91,14 @@ export class AssignUserPermissionDto {
 export class GetUserPermissionsByResourceDto {
   @ApiProperty({
     description: 'User ID to get permissions for',
-    example: 123
+    example: 123,
   })
   @IsNumber()
   userId: number;
 
   @ApiProperty({
     description: 'Resource ID to filter permissions by',
-    example: 5
+    example: 5,
   })
   @IsNumber()
   resourceId: number;
@@ -114,9 +127,9 @@ export class UserPermissionResponseDto {
             permission_name: { type: 'string', example: 'course.view' },
             resource_name: { type: 'string', example: 'course' },
             role_name: { type: 'string', example: 'instructor' },
-            permission_type: { type: 'string', example: 'role_based' }
-          }
-        }
+            permission_type: { type: 'string', example: 'role_based' },
+          },
+        },
       },
       extra: {
         type: 'array',
@@ -129,12 +142,12 @@ export class UserPermissionResponseDto {
             action: { type: 'string', example: 'edit' },
             course_name: { type: 'string', example: 'React Bootcamp' },
             permission_type: { type: 'string', example: 'extra' },
-            granted_by_email: { type: 'string', example: 'admin@example.com' }
-          }
-        }
+            granted_by_email: { type: 'string', example: 'admin@example.com' },
+          },
+        },
       },
-      total: { type: 'number', example: 5 }
-    }
+      total: { type: 'number', example: 5 },
+    },
   })
   permissions: {
     roleBased: any[];
@@ -152,9 +165,9 @@ export class UserPermissionResponseDto {
       uniquePermissions: {
         type: 'array',
         items: { type: 'string' },
-        example: ['course.view', 'course.edit', 'course.delete']
-      }
-    }
+        example: ['course.view', 'course.edit', 'course.delete'],
+      },
+    },
   })
   summary: {
     totalPermissions: number;
@@ -164,11 +177,10 @@ export class UserPermissionResponseDto {
   };
 }
 
-
 export class AssignPermissionsToUserDto {
   @ApiProperty({
     description: 'User ID to assign the role to',
-    example: 123
+    example: 123,
   })
   @IsNumber()
   userId: number;
@@ -200,31 +212,38 @@ export class PermissionAssignmentResponseDto {
   message: string;
 }
 
-
 export class AssignPermissionsToRoleDto {
   @ApiProperty({
     description: 'Resource ID to assign the permissions to',
-    example: 123
+    example: 123,
   })
   @IsNumber()
   resourceId: number;
 
   @ApiProperty({
     description: 'Resource ID to assign the permissions to',
-    example: 123
+    example: 123,
   })
   @IsNumber()
   roleId: number;
-  
+
+  @ApiProperty({
+    description: 'Organization ID',
+    example: 1,
+  })
+  @IsNumber()
+  @IsOptional()
+  orgId?: number;
+
   @ApiProperty({
     description: 'Resource ID to assign the permissions to',
-    example: {1: true, 2: false}
+    example: { 1: true, 2: false },
   })
   @IsNotEmptyObject()
   @Transform(({ value }) => {
     // ensure keys are numbers and values are booleans
     return Object.fromEntries(
-      Object.entries(value).map(([key, val]) => [Number(key), Boolean(val)])
+      Object.entries(value).map(([key, val]) => [Number(key), Boolean(val)]),
     );
   })
   permissions: Record<number, boolean>;

--- a/src/rbac/guards/permissions.guard.ts
+++ b/src/rbac/guards/permissions.guard.ts
@@ -1,4 +1,9 @@
-import { Injectable, CanActivate, ExecutionContext, ForbiddenException } from '@nestjs/common';
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+} from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { RbacPermissionService } from '../rbac.permission.service';
 
@@ -6,29 +11,47 @@ import { RbacPermissionService } from '../rbac.permission.service';
 export class PermissionsGuard implements CanActivate {
   constructor(
     private reflector: Reflector,
-    private rbacPermissionService: RbacPermissionService
+    private rbacPermissionService: RbacPermissionService,
   ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
-    const requiredPermissions = this.reflector.get<string[]>('permissions', context.getHandler());
-    
+    const requiredPermissions = this.reflector.get<string[]>(
+      'permissions',
+      context.getHandler(),
+    );
+
     // If no permissions are required, allow access
     if (!requiredPermissions || requiredPermissions.length === 0) {
       return true;
     }
 
     const request = context.switchToHttp().getRequest();
-    const user = request.user;
+    const user = request.user[0]; // Assuming user is an array as seen in controllers
 
     // Check if user exists and has an ID
     if (!user || !user.id) {
       throw new ForbiddenException('User not authenticated');
     }
 
+    // Super Admin bypass
+    if (user.roles && user.roles.includes('super_admin')) {
+      return true;
+    }
+
+    const orgId = user.orgId;
+    if (!orgId) {
+      throw new ForbiddenException('Organization context missing');
+    }
+
     try {
       // Check if user has all required permissions
-      const hasPermissions = await this.rbacPermissionService.userHasPermissions(user.id, requiredPermissions);
-      
+      const hasPermissions =
+        await this.rbacPermissionService.userHasPermissions(
+          user.id,
+          requiredPermissions,
+          orgId,
+        );
+
       if (!hasPermissions) {
         throw new ForbiddenException('Insufficient permissions');
       }

--- a/src/rbac/rbac.alloc-perms.service.ts
+++ b/src/rbac/rbac.alloc-perms.service.ts
@@ -1,50 +1,92 @@
-import { Injectable, InternalServerErrorException, Logger, NotFoundException } from '@nestjs/common';
+import {
+  Injectable,
+  InternalServerErrorException,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
 import { db } from 'src/db/index';
 import { inArray, sql, eq, and } from 'drizzle-orm';
-import { userRoles, zuvyPermissions, zuvyPermissionsRoles, zuvyResources, zuvyRolePermissions, zuvyUserRoles, zuvyUserRolesAssigned } from 'drizzle/schema';
+import {
+  userRoles,
+  zuvyPermissions,
+  zuvyPermissionsRoles,
+  zuvyResources,
+  zuvyUserRoles,
+  zuvyUserRolesAssigned,
+} from 'drizzle/schema';
 import { ResourceList } from './utility';
 import { PermissionsAllocationService } from 'src/permissions/permissions.alloc.service';
 
 @Injectable()
 export class RbacAllocPermsService {
   constructor(
-    private readonly permissionAllocationService: PermissionsAllocationService
-  ){}
+    private readonly permissionAllocationService: PermissionsAllocationService,
+  ) {}
   private readonly logger = new Logger(RbacAllocPermsService.name);
 
-  async getUserPermissionsByResource(userId: bigint, resourceId: number): Promise<any> {
+  async getUserPermissionsByResource(
+    userId: bigint,
+    resourceId: number,
+    orgId: number,
+  ): Promise<any> {
     try {
-      await this.permissionAllocationService.getUserPermissionsByResource(userId, resourceId);
+      await this.permissionAllocationService.getUserPermissionsByResource(
+        userId,
+        resourceId,
+        orgId,
+      );
     } catch (err) {
-      this.logger.error(`Error getting user permissions for user ${userId} and resource ${resourceId}:`, err);
+      this.logger.error(
+        `Error getting user permissions for user ${userId} and resource ${resourceId}:`,
+        err,
+      );
       if (err instanceof NotFoundException) throw err;
-      throw new InternalServerErrorException('Failed to retrieve user permissions');
+      throw new InternalServerErrorException(
+        'Failed to retrieve user permissions',
+      );
     }
   }
 
-  async getUserPermissionsForMultipleResources(userId: bigint): Promise<any> {
+  async getUserPermissionsForMultipleResources(
+    userId: bigint,
+    orgId: number,
+  ): Promise<any> {
     try {
-      return await this.permissionAllocationService.getUserPermissionsForMultipleResources(userId);
+      return await this.permissionAllocationService.getUserPermissionsForMultipleResources(
+        userId,
+        orgId,
+      );
     } catch (err) {
       this.logger.error(
         `Error in getUserPermissionsForMultipleResources for user ${userId}:`,
         err,
       );
       if (err instanceof NotFoundException) throw err;
-      throw new InternalServerErrorException('Failed to retrieve user permissions');
+      throw new InternalServerErrorException(
+        'Failed to retrieve user permissions',
+      );
     }
   }
 
-  async checkUserPermission(userId: number, resourceId: number, permissionName: string): Promise<any> {
+  async checkUserPermission(
+    userId: number,
+    resourceId: number,
+    permissionName: string,
+    orgId: number,
+  ): Promise<any> {
     try {
       // First check if user exists
-      const userCheck = await db.execute(sql`SELECT id FROM main.users WHERE id = ${userId} LIMIT 1`);
+      const userCheck = await db.execute(
+        sql`SELECT id FROM main.users WHERE id = ${userId} LIMIT 1`,
+      );
       if (!(userCheck as any).rows?.length) {
         throw new NotFoundException('User not found');
       }
 
       // Check if resource exists
-      const resourceCheck = await db.execute(sql`SELECT id, name FROM main.zuvy_resources WHERE id = ${resourceId} LIMIT 1`);
+      const resourceCheck = await db.execute(
+        sql`SELECT id, name FROM main.zuvy_resources WHERE id = ${resourceId} LIMIT 1`,
+      );
       if (!(resourceCheck as any).rows?.length) {
         throw new NotFoundException('Resource not found');
       }
@@ -59,10 +101,12 @@ export class RbacAllocPermsService {
           'role_based' as permission_type
         FROM main.zuvy_permissions p
         INNER JOIN main.zuvy_resources r ON p.resources_id = r.id
-        INNER JOIN main.zuvy_role_permissions rp ON p.id = rp.permission_id
-        INNER JOIN main.zuvy_user_roles ur ON rp.role_id = ur.id
+        INNER JOIN main.zuvy_permissions_roles pr ON p.id = pr.permission_id
+        INNER JOIN main.zuvy_user_roles ur ON pr.role_id = ur.id
         INNER JOIN main.zuvy_user_roles_assigned ura ON ura.role_id = ur.id
-        WHERE ura.user_id = ${userId} AND r.id = ${resourceId} AND p.name = ${permissionName}
+        WHERE ura.user_id = ${userId} AND ura.organization_id = ${orgId}
+          AND pr.org_id = ${orgId}
+          AND r.id = ${resourceId} AND p.name = ${permissionName}
       `);
 
       // Check extra permission
@@ -98,16 +142,19 @@ export class RbacAllocPermsService {
           hasPermission,
           permissionSources: {
             roleBased: hasRolePermission,
-            extra: hasExtraPermission
+            extra: hasExtraPermission,
           },
           details: {
             roleBased: hasRolePermission ? (rolePermission as any).rows : [],
-            extra: hasExtraPermission ? (extraPermission as any).rows : []
-          }
-        }
+            extra: hasExtraPermission ? (extraPermission as any).rows : [],
+          },
+        },
       };
     } catch (err) {
-      this.logger.error(`Error checking permission for user ${userId}, resource ${resourceId}, permission ${permissionName}:`, err);
+      this.logger.error(
+        `Error checking permission for user ${userId}, resource ${resourceId}, permission ${permissionName}:`,
+        err,
+      );
       if (err instanceof NotFoundException) throw err;
       throw new InternalServerErrorException('Failed to check user permission');
     }
@@ -115,7 +162,7 @@ export class RbacAllocPermsService {
 
   async formatPermissionsAndCompare(
     rolePermissions: string[],
-    targetPermissions: string[]
+    targetPermissions: string[],
   ): Promise<Record<string, boolean>> {
     try {
       const permissions: Record<string, boolean> = {};
@@ -132,13 +179,20 @@ export class RbacAllocPermsService {
     }
   }
 
-  async getAllPermissions(roleName: string[], targetPermissions: string[], resourceIds?: number): Promise<any> {
+  async getAllPermissions(
+    roleName: string[],
+    targetPermissions: string[],
+    orgId: number,
+  ): Promise<any> {
     try {
-      return await this.permissionAllocationService.getAllPermissions(roleName, targetPermissions);
-    }
-    catch (err) {
+      return await this.permissionAllocationService.getAllPermissions(
+        roleName,
+        targetPermissions,
+        orgId,
+      );
+    } catch (err) {
       this.logger.error('Error retrieving all permissions:', err);
-      throw new InternalServerErrorException('Failed to retrieve permissions');
+      throw err;
     }
   }
 }

--- a/src/rbac/rbac.controller.ts
+++ b/src/rbac/rbac.controller.ts
@@ -1,8 +1,41 @@
-import { Controller, Post, Get, Body, HttpStatus, HttpException, UsePipes, ValidationPipe, UseGuards, Delete, Param, ParseIntPipe, Query, Put } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse, ApiBody, ApiBearerAuth, ApiQuery, ApiParam } from '@nestjs/swagger';
+import {
+  Controller,
+  Post,
+  Get,
+  Body,
+  HttpStatus,
+  HttpException,
+  UsePipes,
+  ValidationPipe,
+  UseGuards,
+  Delete,
+  Param,
+  ParseIntPipe,
+  Query,
+  Put,
+  Req,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBody,
+  ApiBearerAuth,
+  ApiQuery,
+  ApiParam,
+} from '@nestjs/swagger';
 import { RbacPermissionService } from './rbac.permission.service';
 import { RbacAllocPermsService } from './rbac.alloc-perms.service';
-import { CreatePermissionDto, PermissionResponseDto, AssignUserPermissionDto, GetUserPermissionsByResourceDto, UserPermissionResponseDto, AssignPermissionsToUserDto, PermissionAssignmentResponseDto, AssignPermissionsToRoleDto } from './dto/permission.dto';
+import {
+  CreatePermissionDto,
+  PermissionResponseDto,
+  AssignUserPermissionDto,
+  GetUserPermissionsByResourceDto,
+  UserPermissionResponseDto,
+  AssignPermissionsToUserDto,
+  PermissionAssignmentResponseDto,
+  AssignPermissionsToRoleDto,
+} from './dto/permission.dto';
 import { RbacResourcesService } from './rbac.resources.service';
 import { CreateResourceDto } from './dto/resources.dto';
 import { bigint } from 'drizzle-orm/mysql-core';
@@ -26,71 +59,83 @@ export class RbacController {
     private readonly rbacPermissionService: RbacPermissionService,
     private readonly rbacService: RbacService,
     private readonly resourcesService: RbacResourcesService,
-  ) { }
+  ) {}
 
   @Post('permissions')
   //   @RequirePermissions('create_permission')
   @ApiOperation({
     summary: 'Create a new permission',
-    description: 'Adds a new permission with name, resource ID and optional description'
+    description:
+      'Adds a new permission with name, resource ID and optional description',
   })
   @ApiBody({
     type: CreatePermissionDto,
-    description: 'Permission data to create'
+    description: 'Permission data to create',
   })
   @ApiResponse({
     status: 201,
     description: 'Permission created successfully',
-    type: PermissionResponseDto
+    type: PermissionResponseDto,
   })
   @ApiResponse({
     status: 400,
-    description: 'Bad request - Invalid input data or resource not found'
+    description: 'Bad request - Invalid input data or resource not found',
   })
   @ApiResponse({
     status: 500,
-    description: 'Internal server error'
+    description: 'Internal server error',
   })
   @ApiBearerAuth('JWT-auth')
-  async createPermission(@Body() createPermissionDto: CreatePermissionDto): Promise<any> {
+  async createPermission(
+    @Body() createPermissionDto: CreatePermissionDto,
+  ): Promise<any> {
     try {
-      const result = await this.rbacPermissionService.createPermission(createPermissionDto);
+      const result =
+        await this.rbacPermissionService.createPermission(createPermissionDto);
       return result;
     } catch (error) {
       if (error instanceof HttpException) {
         throw error;
       }
       if (error.code === '23505') {
-        throw new HttpException('Permission with this name already exists', HttpStatus.BAD_REQUEST);
+        throw new HttpException(
+          'Permission with this name already exists',
+          HttpStatus.BAD_REQUEST,
+        );
       }
-      throw new HttpException('Internal Server Error', HttpStatus.INTERNAL_SERVER_ERROR);
+      throw new HttpException(
+        'Internal Server Error',
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
     }
   }
 
   @Get('get/all/permissions')
   @ApiOperation({
     summary: 'Get all permissions',
-    description: 'Retrieves all permissions from the system with pagination, search, and filtering. Optional parameters for resourceId, search, page, and limit.'
+    description:
+      'Retrieves all permissions from the system with pagination, search, and filtering. Optional parameters for resourceId, search, page, and limit.',
   })
   @ApiQuery({
     name: 'resourceId',
     required: false,
     description: 'Optional resource ID to filter permissions by resource',
-    type: Number
+    type: Number,
   })
   @ApiQuery({
     name: 'searchPermission',
     required: false,
-    description: 'Optional search term to filter permissions by name or description',
-    type: String
+    description:
+      'Optional search term to filter permissions by name or description',
+    type: String,
   })
   @ApiResponse({
     status: 200,
-    description: 'Permissions retrieved successfully'
+    description: 'Permissions retrieved successfully',
   })
   @ApiResponse({
     status: 500,
-    description: 'Internal server error'
+    description: 'Internal server error',
   })
   @ApiBearerAuth('JWT-auth')
   async getAllPermissions(
@@ -98,10 +143,16 @@ export class RbacController {
     @Query('searchPermission') searchPermission?: string,
   ): Promise<any> {
     try {
-      const result = await this.rbacPermissionService.getAllPermissions(resourceId, searchPermission);
+      const result = await this.rbacPermissionService.getAllPermissions(
+        resourceId,
+        searchPermission,
+      );
       return result;
     } catch (error) {
-      throw new HttpException('Internal Server Error', HttpStatus.INTERNAL_SERVER_ERROR);
+      throw new HttpException(
+        'Internal Server Error',
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
     }
   }
 
@@ -127,37 +178,43 @@ export class RbacController {
   //   }
   // }
 
-
   @Post('assign/permissionsToRole')
   @ApiOperation({
     summary: 'Assign permissions to role',
-    description: 'Admin can assign specific permissions to a role'
+    description: 'Admin can assign specific permissions to a role',
   })
   @ApiBody({
     type: AssignPermissionsToRoleDto,
-    description: 'Role ID and permissions to assign'
+    description: 'Role ID and permissions to assign',
   })
   @ApiResponse({
     status: 201,
     description: 'Permissions assigned successfully',
-    type: PermissionAssignmentResponseDto
+    type: PermissionAssignmentResponseDto,
   })
   @ApiResponse({
     status: 400,
-    description: 'Bad request - Invalid input data or role not found'
+    description: 'Bad request - Invalid input data or role not found',
   })
   @ApiResponse({
     status: 404,
-    description: 'Role not found'
+    description: 'Role not found',
   })
   @ApiResponse({
     status: 500,
-    description: 'Internal server error'
+    description: 'Internal server error',
   })
   @ApiBearerAuth('JWT-auth')
-  async assignPermissionsToRole(@Body() assignPermissionsDto: AssignPermissionsToRoleDto): Promise<any> {
+  async assignPermissionsToRole(
+    @Body() assignPermissionsDto: AssignPermissionsToRoleDto,
+    @Req() req,
+  ): Promise<any> {
     try {
-      const result = await this.rbacPermissionService.assignPermissionsToRole(assignPermissionsDto);
+      const orgId = req.user[0]?.orgId;
+      const result = await this.rbacPermissionService.assignPermissionsToRole(
+        assignPermissionsDto,
+        orgId,
+      );
       return result;
     } catch (error) {
       if (error instanceof HttpException) {
@@ -167,42 +224,53 @@ export class RbacController {
         throw new HttpException('Role not found', HttpStatus.NOT_FOUND);
       }
       if (error.code === '23505') {
-        throw new HttpException('Permission already assigned to role', HttpStatus.BAD_REQUEST);
+        throw new HttpException(
+          'Permission already assigned to role',
+          HttpStatus.BAD_REQUEST,
+        );
       }
-      throw new HttpException('Internal Server Error', HttpStatus.INTERNAL_SERVER_ERROR);
+      throw new HttpException(
+        'Internal Server Error',
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
     }
   }
 
   @Post('assign/permissions/to/user')
   @ApiOperation({
     summary: 'Assign permissions to user',
-    description: 'Admin can assign specific permissions to a user'
+    description: 'Admin can assign specific permissions to a user',
   })
   @ApiBody({
     type: AssignPermissionsToUserDto,
-    description: 'User ID and permissions to assign'
+    description: 'User ID and permissions to assign',
   })
   @ApiResponse({
     status: 201,
     description: 'Permissions assigned successfully',
-    type: PermissionAssignmentResponseDto
+    type: PermissionAssignmentResponseDto,
   })
   @ApiResponse({
     status: 400,
-    description: 'Bad request - Invalid input data or user/role not found'
+    description: 'Bad request - Invalid input data or user/role not found',
   })
   @ApiResponse({
     status: 404,
-    description: 'User or role not found'
+    description: 'User or role not found',
   })
   @ApiResponse({
     status: 500,
-    description: 'Internal server error'
+    description: 'Internal server error',
   })
   @ApiBearerAuth('JWT-auth')
-  async assignPermissionsToUser(@Body() assignPermissionsDto: AssignPermissionsToUserDto): Promise<any> {
+  async assignPermissionsToUser(
+    @Body() assignPermissionsDto: AssignPermissionsToUserDto,
+  ): Promise<any> {
     try {
-      const result = await this.rbacPermissionService.assignPermissionsToUser(assignPermissionsDto);
+      const result =
+        await this.rbacPermissionService.assignPermissionsToUser(
+          assignPermissionsDto,
+        );
       return result;
     } catch (error) {
       if (error instanceof HttpException) {
@@ -212,75 +280,101 @@ export class RbacController {
         throw new HttpException('User or role not found', HttpStatus.NOT_FOUND);
       }
       if (error.code === '23505') {
-        throw new HttpException('Permission already assigned to user', HttpStatus.BAD_REQUEST);
+        throw new HttpException(
+          'Permission already assigned to user',
+          HttpStatus.BAD_REQUEST,
+        );
       }
-      throw new HttpException('Internal Server Error', HttpStatus.INTERNAL_SERVER_ERROR);
+      throw new HttpException(
+        'Internal Server Error',
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
     }
   }
 
   @Get('users/:userId/permissions/:resourceId')
   @ApiOperation({
     summary: 'Get user permissions for a specific resource',
-    description: 'Retrieves all permissions (role-based and extra) that a user has for a specific resource'
+    description:
+      'Retrieves all permissions (role-based and extra) that a user has for a specific resource',
   })
   @ApiResponse({
     status: 200,
     description: 'User permissions retrieved successfully',
-    type: UserPermissionResponseDto
+    type: UserPermissionResponseDto,
   })
   @ApiResponse({
     status: 404,
-    description: 'User or resource not found'
+    description: 'User or resource not found',
   })
   @ApiResponse({
     status: 500,
-    description: 'Internal server error'
+    description: 'Internal server error',
   })
   @ApiBearerAuth('JWT-auth')
   async getUserPermissionsByResource(
     @Param('userId', ParseIntPipe) userId: bigint,
-    @Param('resourceId', ParseIntPipe) resourceId: number
+    @Param('resourceId', ParseIntPipe) resourceId: number,
+    @Req() req,
   ): Promise<any> {
     try {
-      const result = await this.rbacService.getUserPermissionsByResource(userId, resourceId);
+      const orgId = req.user[0]?.orgId;
+      const result = await this.rbacService.getUserPermissionsByResource(
+        userId,
+        resourceId,
+        orgId,
+      );
       return result;
     } catch (error) {
       if (error instanceof HttpException) {
         throw error;
       }
-      throw new HttpException('Internal Server Error', HttpStatus.INTERNAL_SERVER_ERROR);
+      throw new HttpException(
+        'Internal Server Error',
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
     }
   }
 
   @Get('users/:userId/permissions-multiple')
   @ApiOperation({
     summary: 'Get user permissions for multiple resources',
-    description: 'Retrieves permissions for course, contentBank, and roles and permissions resources'
+    description:
+      'Retrieves permissions for course, contentBank, and roles and permissions resources',
   })
   @ApiResponse({
     status: 200,
-    description: 'User permissions retrieved successfully'
+    description: 'User permissions retrieved successfully',
   })
   @ApiResponse({
     status: 404,
-    description: 'User not found'
+    description: 'User not found',
   })
   @ApiResponse({
     status: 500,
-    description: 'Internal server error'
+    description: 'Internal server error',
   })
   @ApiBearerAuth('JWT-auth')
   async getUserPermissionsForMultipleResources(
-    @Param('userId', ParseIntPipe) userId: bigint
+    @Param('userId', ParseIntPipe) userId: bigint,
+    @Req() req,
   ): Promise<any> {
     try {
-      const result = await this.rbacService.getUserPermissionsForMultipleResources(userId);
+      const orgId = req.user[0]?.orgId;
+      const result =
+        await this.rbacService.getUserPermissionsForMultipleResources(
+          userId,
+          orgId,
+        );
       return result;
     } catch (error) {
       if (error instanceof HttpException) {
         throw error;
       }
-      throw new HttpException('Internal Server Error', HttpStatus.INTERNAL_SERVER_ERROR);
+      throw new HttpException(
+        'Internal Server Error',
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
     }
   }
 
@@ -288,19 +382,19 @@ export class RbacController {
   //   @RequirePermissions('delete_permission')
   @ApiOperation({
     summary: 'Delete a permission by id',
-    description: 'Deletes a permission record by its numeric id'
+    description: 'Deletes a permission record by its numeric id',
   })
   @ApiResponse({
     status: 200,
-    description: 'Permission deleted successfully'
+    description: 'Permission deleted successfully',
   })
   @ApiResponse({
     status: 404,
-    description: 'Permission not found'
+    description: 'Permission not found',
   })
   @ApiResponse({
     status: 500,
-    description: 'Internal server error'
+    description: 'Internal server error',
   })
   @ApiBearerAuth('JWT-auth')
   async deletePermission(@Param('id', ParseIntPipe) id: number): Promise<any> {
@@ -311,19 +405,22 @@ export class RbacController {
       if (error instanceof HttpException) {
         throw error;
       }
-      throw new HttpException('Internal Server Error', HttpStatus.INTERNAL_SERVER_ERROR);
+      throw new HttpException(
+        'Internal Server Error',
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
     }
   }
-
 
   @Post('/newResource')
   @ApiOperation({
     summary: 'Create a new resource',
-    description: 'Adds a new resource to the system with the specified name and description'
+    description:
+      'Adds a new resource to the system with the specified name and description',
   })
   @ApiBody({
     type: CreateResourceDto,
-    description: 'Resource data to create'
+    description: 'Resource data to create',
   })
   @ApiResponse({
     status: 201,
@@ -333,43 +430,55 @@ export class RbacController {
       properties: {
         id: { type: 'number', example: 1 },
         name: { type: 'string', example: 'course' },
-        description: { type: 'string', example: 'Manages course-related operations', nullable: true }
-      }
-    }
+        description: {
+          type: 'string',
+          example: 'Manages course-related operations',
+          nullable: true,
+        },
+      },
+    },
   })
   @ApiResponse({
     status: 400,
-    description: 'Bad request - Invalid input data or duplicate name'
+    description: 'Bad request - Invalid input data or duplicate name',
   })
   @ApiResponse({
     status: 500,
-    description: 'Internal server error'
+    description: 'Internal server error',
   })
   @ApiBearerAuth('JWT-auth')
   async createResource(@Body() createResourceDto: CreateResourceDto) {
     try {
-      const result = await this.resourcesService.createResource(createResourceDto);
+      const result =
+        await this.resourcesService.createResource(createResourceDto);
       return result;
     } catch (error) {
-      if (error.code === '23505') { // PostgreSQL unique constraint violation
-        throw new HttpException('Resource with this name already exists', HttpStatus.BAD_REQUEST);
+      if (error.code === '23505') {
+        // PostgreSQL unique constraint violation
+        throw new HttpException(
+          'Resource with this name already exists',
+          HttpStatus.BAD_REQUEST,
+        );
       }
-      throw new HttpException('Internal Server Error', HttpStatus.INTERNAL_SERVER_ERROR);
+      throw new HttpException(
+        'Internal Server Error',
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
     }
   }
 
   @Get('resources')
   @ApiOperation({
     summary: 'Get all resources',
-    description: 'Retrieves all resources from the system'
+    description: 'Retrieves all resources from the system',
   })
   @ApiResponse({
     status: 200,
-    description: 'Resources retrieved successfully'
+    description: 'Resources retrieved successfully',
   })
   @ApiResponse({
     status: 500,
-    description: 'Internal server error'
+    description: 'Internal server error',
   })
   @ApiBearerAuth('JWT-auth')
   async getAllResources(): Promise<any> {
@@ -380,19 +489,22 @@ export class RbacController {
       if (error instanceof HttpException) {
         throw error;
       }
-      throw new HttpException('Internal Server Error', HttpStatus.INTERNAL_SERVER_ERROR);
+      throw new HttpException(
+        'Internal Server Error',
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
     }
   }
 
   @Get(':id')
   @ApiOperation({
     summary: 'Get resource by ID',
-    description: 'Retrieves a specific resource by its ID'
+    description: 'Retrieves a specific resource by its ID',
   })
   @ApiParam({
     name: 'id',
     description: 'Resource ID',
-    type: Number
+    type: Number,
   })
   @ApiResponse({
     status: 200,
@@ -402,17 +514,21 @@ export class RbacController {
       properties: {
         id: { type: 'number', example: 1 },
         name: { type: 'string', example: 'course' },
-        description: { type: 'string', example: 'Manages course-related operations', nullable: true }
-      }
-    }
+        description: {
+          type: 'string',
+          example: 'Manages course-related operations',
+          nullable: true,
+        },
+      },
+    },
   })
   @ApiResponse({
     status: 404,
-    description: 'Resource not found'
+    description: 'Resource not found',
   })
   @ApiResponse({
     status: 500,
-    description: 'Internal server error'
+    description: 'Internal server error',
   })
   @ApiBearerAuth('JWT-auth')
   async getResourceById(@Param('id', ParseIntPipe) id: number) {
@@ -423,23 +539,26 @@ export class RbacController {
       if (error.status === HttpStatus.NOT_FOUND) {
         throw error;
       }
-      throw new HttpException('Internal Server Error', HttpStatus.INTERNAL_SERVER_ERROR);
+      throw new HttpException(
+        'Internal Server Error',
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
     }
   }
 
   @Put('resource/:id')
   @ApiOperation({
     summary: 'Update a resource',
-    description: 'Updates an existing resource with new data'
+    description: 'Updates an existing resource with new data',
   })
   @ApiParam({
     name: 'id',
     description: 'Resource ID to update',
-    type: Number
+    type: Number,
   })
   @ApiBody({
     type: CreateResourceDto,
-    description: 'Updated resource data'
+    description: 'Updated resource data',
   })
   @ApiResponse({
     status: 200,
@@ -449,57 +568,70 @@ export class RbacController {
       properties: {
         id: { type: 'number', example: 1 },
         name: { type: 'string', example: 'course' },
-        description: { type: 'string', example: 'Manages course-related operations', nullable: true }
-      }
-    }
+        description: {
+          type: 'string',
+          example: 'Manages course-related operations',
+          nullable: true,
+        },
+      },
+    },
   })
   @ApiResponse({
     status: 400,
-    description: 'Bad request - Invalid input data or duplicate name'
+    description: 'Bad request - Invalid input data or duplicate name',
   })
   @ApiResponse({
     status: 404,
-    description: 'Resource not found'
+    description: 'Resource not found',
   })
   @ApiResponse({
     status: 500,
-    description: 'Internal server error'
+    description: 'Internal server error',
   })
   @ApiBearerAuth('JWT-auth')
   async updateResource(
     @Param('id', ParseIntPipe) id: number,
-    @Body() updateResourceDto: CreateResourceDto
+    @Body() updateResourceDto: CreateResourceDto,
   ) {
     try {
-      const result = await this.resourcesService.updateResource(id, updateResourceDto);
+      const result = await this.resourcesService.updateResource(
+        id,
+        updateResourceDto,
+      );
       return result;
     } catch (error) {
       if (error.code === '23505') {
-        throw new HttpException('Resource with this name already exists', HttpStatus.BAD_REQUEST);
+        throw new HttpException(
+          'Resource with this name already exists',
+          HttpStatus.BAD_REQUEST,
+        );
       }
       if (error.status === HttpStatus.NOT_FOUND) {
         throw error;
       }
-      throw new HttpException('Internal Server Error', HttpStatus.INTERNAL_SERVER_ERROR);
+      throw new HttpException(
+        'Internal Server Error',
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
     }
   }
 
   @Delete('deleteResource/:id')
   @ApiOperation({
     summary: 'Delete a resource',
-    description: 'Deletes a specific resource by its ID'
+    description: 'Deletes a specific resource by its ID',
   })
   @ApiResponse({
     status: 204,
-    description: 'Resource deleted successfully'
+    description: 'Resource deleted successfully',
   })
   @ApiResponse({
     status: 404,
-    description: 'Resource not found'
+    description: 'Resource not found',
   })
   @ApiResponse({
     status: 500,
-    description: 'Internal server error'
+    description: 'Internal server error',
   })
   @ApiBearerAuth('JWT-auth')
   async deleteResource(@Param('id', ParseIntPipe) id: number) {
@@ -509,5 +641,4 @@ export class RbacController {
       throw error;
     }
   }
-
 }

--- a/src/rbac/rbac.permission.service.ts
+++ b/src/rbac/rbac.permission.service.ts
@@ -1,31 +1,59 @@
-import { BadRequestException, ConflictException, Injectable, InternalServerErrorException, Logger, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  InternalServerErrorException,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
 import { db } from 'src/db/index';
 import { sql, eq, and, asc, ilike, or, inArray } from 'drizzle-orm';
-import { CreatePermissionDto, AssignUserPermissionDto, AssignPermissionsToUserDto, AssignPermissionsToRoleDto } from './dto/permission.dto';
-import { users, zuvyPermissions, zuvyResources, zuvyPermissionsRoles, zuvyRolePermissions, zuvyUserPermissions, zuvyUserRoles, zuvyUserRolesAssigned } from 'drizzle/schema';
+import {
+  CreatePermissionDto,
+  AssignUserPermissionDto,
+  AssignPermissionsToUserDto,
+  AssignPermissionsToRoleDto,
+} from './dto/permission.dto';
+import {
+  users,
+  zuvyPermissions,
+  zuvyResources,
+  zuvyPermissionsRoles,
+  zuvyUserPermissions,
+  zuvyUserRoles,
+  zuvyUserRolesAssigned,
+} from 'drizzle/schema';
 
 @Injectable()
 export class RbacPermissionService {
   private readonly logger = new Logger(RbacPermissionService.name);
 
-  async createPermission(createPermissionDto: CreatePermissionDto): Promise<any> {
+  async createPermission(
+    createPermissionDto: CreatePermissionDto,
+  ): Promise<any> {
     try {
       const { name, resourceId, description } = createPermissionDto;
 
       // Check if resource exists
-      const resourceCheck = await db.execute(sql`SELECT id FROM main.zuvy_resources WHERE id = ${resourceId} LIMIT 1`);
+      const resourceCheck = await db.execute(
+        sql`SELECT id FROM main.zuvy_resources WHERE id = ${resourceId} LIMIT 1`,
+      );
       if (!(resourceCheck as any).rows?.length) {
         throw new NotFoundException('Resource not found');
       }
 
       // Check if permission with the same name already exists for this resource
-      const permissionCheck = await db.execute(sql`SELECT id FROM main.zuvy_permissions WHERE name = ${name} AND resource_id = ${resourceId} LIMIT 1`);
+      const permissionCheck = await db.execute(
+        sql`SELECT id FROM main.zuvy_permissions WHERE name = ${name} AND resource_id = ${resourceId} LIMIT 1`,
+      );
       if ((permissionCheck as any).rows?.length) {
-        throw new BadRequestException('Permission with this name already exists for the specified resource');
+        throw new BadRequestException(
+          'Permission with this name already exists for the specified resource',
+        );
       }
       // Create new permission
       const result = await db.execute(
-        sql`INSERT INTO main.zuvy_permissions (name, resource_id, description) VALUES (${name}, ${resourceId}, ${description ?? null}) RETURNING *`
+        sql`INSERT INTO main.zuvy_permissions (name, resource_id, description) VALUES (${name}, ${resourceId}, ${description ?? null}) RETURNING *`,
       );
 
       if ((result as any).rows.length > 0) {
@@ -37,29 +65,32 @@ export class RbacPermissionService {
             name: zuvyPermissions.name,
             resourceId: zuvyPermissions.resourcesId,
             description: zuvyPermissions.description,
-            resourceName: zuvyResources.name
+            resourceName: zuvyResources.name,
           })
           .from(zuvyPermissions)
-          .leftJoin(zuvyResources, eq(zuvyPermissions.resourcesId, zuvyResources.id))
+          .leftJoin(
+            zuvyResources,
+            eq(zuvyPermissions.resourcesId, zuvyResources.id),
+          )
           .where(eq(zuvyPermissions.resourcesId, resourceId))
           .orderBy(asc(zuvyPermissions.id));
 
         const allPermissionsResult = {
           rows: allPermissions,
-          rowCount: allPermissions.length
+          rowCount: allPermissions.length,
         };
 
         return {
           status: 'success',
           message: 'Permission created successfully',
           code: 200,
-          data: allPermissionsResult
+          data: allPermissionsResult,
         };
       } else {
         return {
           status: 'error',
           code: 400,
-          message: 'Permission creation failed. Please try again'
+          message: 'Permission creation failed. Please try again',
         };
       }
     } catch (err) {
@@ -70,7 +101,7 @@ export class RbacPermissionService {
 
   async getAllPermissions(
     resourceId?: number,
-    search?: string
+    search?: string,
   ): Promise<[any, any]> {
     try {
       // Build the where conditions
@@ -85,12 +116,13 @@ export class RbacPermissionService {
           or(
             ilike(zuvyPermissions.name, `%${search}%`),
             ilike(zuvyPermissions.description, `%${search}%`),
-            ilike(zuvyResources.name, `%${search}%`)
-          )
+            ilike(zuvyResources.name, `%${search}%`),
+          ),
         );
       }
 
-      const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
+      const whereClause =
+        conditions.length > 0 ? and(...conditions) : undefined;
 
       const dataResult = await db
         .select({
@@ -99,10 +131,16 @@ export class RbacPermissionService {
           resourceId: zuvyPermissions.resourcesId,
           description: zuvyPermissions.description,
           resourceName: zuvyResources.name,
-          granted: sql<boolean>`EXISTS (SELECT 1 FROM ${zuvyPermissionsRoles} pr WHERE pr.permission_id = ${zuvyPermissions.id})`.as('granted')
+          granted:
+            sql<boolean>`EXISTS (SELECT 1 FROM ${zuvyPermissionsRoles} pr WHERE pr.permission_id = ${zuvyPermissions.id})`.as(
+              'granted',
+            ),
         })
         .from(zuvyPermissions)
-        .leftJoin(zuvyResources, eq(zuvyPermissions.resourcesId, zuvyResources.id))
+        .leftJoin(
+          zuvyResources,
+          eq(zuvyPermissions.resourcesId, zuvyResources.id),
+        )
         .where(whereClause)
         .orderBy(asc(zuvyPermissions.id));
 
@@ -110,7 +148,10 @@ export class RbacPermissionService {
       const countResult = await db
         .select({ count: sql<number>`count(*)` })
         .from(zuvyPermissions)
-        .leftJoin(zuvyResources, eq(zuvyPermissions.resourcesId, zuvyResources.id))
+        .leftJoin(
+          zuvyResources,
+          eq(zuvyPermissions.resourcesId, zuvyResources.id),
+        )
         .where(whereClause);
 
       return [
@@ -121,7 +162,7 @@ export class RbacPermissionService {
           code: 200,
           data: dataResult,
           totalPages: dataResult.length,
-        }
+        },
       ];
     } catch (err) {
       this.logger.error('Error retrieving permissions:', err);
@@ -137,7 +178,9 @@ export class RbacPermissionService {
         .from(zuvyPermissionsRoles)
         .where(eq(zuvyPermissionsRoles.permissionId, id));
       if (associatedRoles.length > 0) {
-        throw new BadRequestException('Cannot delete permission associated with roles. Please remove associations first.');
+        throw new BadRequestException(
+          'Cannot delete permission associated with roles. Please remove associations first.',
+        );
       }
       // If there are no associated roles, the permission is deleted successfully
       const deletedPermission = await db
@@ -147,40 +190,54 @@ export class RbacPermissionService {
         throw new NotFoundException(`Permission with ID ${id} not found`);
       }
       // Permission deleted successfully then return the permission details
-      return { message: 'Permission deleted successfully', code: 200, status: 'success'};
+      return {
+        message: 'Permission deleted successfully',
+        code: 200,
+        status: 'success',
+      };
     } catch (err) {
       throw err;
     }
   }
 
-  async getUserPermissions(userId: number): Promise<string[]> {
+  async getUserPermissions(userId: number, orgId: number): Promise<string[]> {
     try {
       const result = await db.execute(sql`
         SELECT DISTINCT p.name 
         FROM main.zuvy_permissions p
-        INNER JOIN main.zuvy_role_permissions rp ON p.id = rp.permission_id
-        INNER JOIN main.zuvy_user_roles ur ON rp.role_id = ur.id
+        INNER JOIN main.zuvy_permissions_roles pr ON p.id = pr.permission_id
+        INNER JOIN main.zuvy_user_roles ur ON pr.role_id = ur.id
         INNER JOIN main.zuvy_user_roles_assigned ura ON ura.role_id = ur.id
-        WHERE ura.user_id = ${userId}
+        WHERE ura.user_id = ${userId} AND ura.organization_id = ${orgId}
+          AND pr.org_id = ${orgId}
       `);
 
-      const permissions = (result as any).rows.map(row => row.name);
+      const permissions = (result as any).rows.map((row) => row.name);
       return permissions;
     } catch (err) {
-      this.logger.error(`Error getting user permissions for user ${userId}:`, err);
-      throw new InternalServerErrorException('Failed to retrieve user permissions');
+      this.logger.error(
+        `Error getting user permissions for user ${userId}:`,
+        err,
+      );
+      throw new InternalServerErrorException(
+        'Failed to retrieve user permissions',
+      );
     }
   }
 
-  async userHasPermissions(userId: number, requiredPermissions: string[]): Promise<boolean> {
+  async userHasPermissions(
+    userId: number,
+    requiredPermissions: string[],
+    orgId: number,
+  ): Promise<boolean> {
     try {
       if (!requiredPermissions || requiredPermissions.length === 0) {
         return true;
       }
 
-      const userPermissions = await this.getUserPermissions(userId);
-      const hasAllPermissions = requiredPermissions.every(permission =>
-        userPermissions.includes(permission)
+      const userPermissions = await this.getUserPermissions(userId, orgId);
+      const hasAllPermissions = requiredPermissions.every((permission) =>
+        userPermissions.includes(permission),
       );
 
       return hasAllPermissions;
@@ -190,22 +247,30 @@ export class RbacPermissionService {
     }
   }
 
-  async assignExtraPermissionToUser(payload: AssignUserPermissionDto): Promise<any> {
+  async assignExtraPermissionToUser(
+    payload: AssignUserPermissionDto,
+  ): Promise<any> {
     const { actorUserId, targetUserId, permissionId, scopeId } = payload;
     try {
-      const userCheck = await db.execute(sql`SELECT id FROM main.users WHERE id = ${targetUserId} LIMIT 1`);
+      const userCheck = await db.execute(
+        sql`SELECT id FROM main.users WHERE id = ${targetUserId} LIMIT 1`,
+      );
       if (!(userCheck as any).rows?.length) {
         throw new NotFoundException('Target user not found');
       }
 
       if (actorUserId) {
-        const actorCheck = await db.execute(sql`SELECT id FROM main.users WHERE id = ${actorUserId} LIMIT 1`);
+        const actorCheck = await db.execute(
+          sql`SELECT id FROM main.users WHERE id = ${actorUserId} LIMIT 1`,
+        );
         if (!(actorCheck as any).rows?.length) {
           throw new NotFoundException('Actor user not found');
         }
       }
 
-      const permCheck = await db.execute(sql`SELECT id FROM main.zuvy_permissions WHERE id = ${permissionId} LIMIT 1`);
+      const permCheck = await db.execute(
+        sql`SELECT id FROM main.zuvy_permissions WHERE id = ${permissionId} LIMIT 1`,
+      );
       if (!(permCheck as any).rows?.length) {
         throw new NotFoundException('Permission not found');
       }
@@ -220,28 +285,39 @@ export class RbacPermissionService {
         status: 'success',
         code: 200,
         message: 'Extra permission assignment recorded in audit log',
-        data: (insertAudit as any).rows[0]
+        data: (insertAudit as any).rows[0],
       };
     } catch (err) {
-      this.logger.error('Failed to assign extra permission to user', err as any);
+      this.logger.error(
+        'Failed to assign extra permission to user',
+        err as any,
+      );
       if (err instanceof NotFoundException) throw err;
-      throw new InternalServerErrorException('Failed to assign extra permission');
+      throw new InternalServerErrorException(
+        'Failed to assign extra permission',
+      );
     }
   }
 
   // rbac-permission.service.ts
-  async assignPermissionsToUser(assignPermissionsDto: AssignPermissionsToUserDto): Promise<any> {
+  async assignPermissionsToUser(
+    assignPermissionsDto: AssignPermissionsToUserDto,
+  ): Promise<any> {
     try {
       const { userId, permissions } = assignPermissionsDto;
       console.log('Assigning permissions:', assignPermissionsDto);
       let insertUserPermission;
       // Check if user exists
-      const userExists = await db.execute(sql`SELECT id FROM main.users WHERE id = ${userId} LIMIT 1`);
+      const userExists = await db.execute(
+        sql`SELECT id FROM main.users WHERE id = ${userId} LIMIT 1`,
+      );
       if (!(userExists as any).rows?.length) {
         throw new NotFoundException('User not found');
       }
 
-      const permissionsExists = await db.execute(sql`SELECT id FROM main.zuvy_permissions WHERE id IN (${permissions.map(permission => permission).join(',')}) LIMIT 1`);
+      const permissionsExists = await db.execute(
+        sql`SELECT id FROM main.zuvy_permissions WHERE id IN (${permissions.map((permission) => permission).join(',')}) LIMIT 1`,
+      );
       if (!(permissionsExists as any).rows?.length) {
         throw new NotFoundException('Permissions not found');
       }
@@ -251,7 +327,9 @@ export class RbacPermissionService {
       //   VALUES (${userId}, ${userId}, ${'assign_permissions'}, ${permissions.map(permission => permission.id).join(',')}, ${scopeId ?? null})
       //   RETURNING *
       // `);
-      const alreadyAssignedPermissions = await db.execute(sql`SELECT id FROM main.zuvy_user_permissions WHERE user_id = ${userId} AND permission_id IN (${permissions.map(permission => permission).join(',')}) LIMIT 1`);
+      const alreadyAssignedPermissions = await db.execute(
+        sql`SELECT id FROM main.zuvy_user_permissions WHERE user_id = ${userId} AND permission_id IN (${permissions.map((permission) => permission).join(',')}) LIMIT 1`,
+      );
       if ((alreadyAssignedPermissions as any).rows?.length) {
         throw new BadRequestException('Permissions already assigned to user');
       }
@@ -259,31 +337,39 @@ export class RbacPermissionService {
       for (const permissionId of assignPermissionsDto.permissions) {
         const exists = await db.query.zuvyUserPermissions.findFirst({
           where: (u, { eq, and }) =>
-            and(eq(u.userId, BigInt(assignPermissionsDto.userId)), eq(u.permissionId, permissionId)),
+            and(
+              eq(u.userId, BigInt(assignPermissionsDto.userId)),
+              eq(u.permissionId, permissionId),
+            ),
         });
 
         if (!exists) {
           const insertData = {
             userId: assignPermissionsDto.userId,
             permissionId,
-          }
-          insertUserPermission = await db.insert(zuvyUserPermissions).values(insertData).returning();
+          };
+          insertUserPermission = await db
+            .insert(zuvyUserPermissions)
+            .values(insertData)
+            .returning();
         }
       }
       return {
         status: 'success',
         code: 200,
         message: 'Permissions assigned successfully',
-        data: insertUserPermission
+        data: insertUserPermission,
       };
-
     } catch (error) {
       this.logger.error('Error assigning permissions to user role:', error);
       throw error;
     }
   }
 
-  async assignPermissionsToRole(dto: AssignPermissionsToRoleDto) {
+  async assignPermissionsToRole(
+    dto: AssignPermissionsToRoleDto,
+    orgId: number,
+  ) {
     try {
       const { resourceId, roleId, permissions } = dto;
 
@@ -312,16 +398,24 @@ export class RbacPermissionService {
         const invalid = incomingIds.filter((id) => !validIds.has(id));
         if (invalid.length)
           throw new BadRequestException(
-            `Invalid permission ids for resource: ${invalid.join(', ')}`
+            `Invalid permission ids for resource: ${invalid.join(', ')}`,
           );
 
         const enableIds = incomingIds.filter((id) => permissions[id] === true);
-        const disableIds = incomingIds.filter((id) => permissions[id] === false);
+        const disableIds = incomingIds.filter(
+          (id) => permissions[id] === false,
+        );
 
         if (enableIds.length) {
           await tx
             .insert(zuvyPermissionsRoles)
-            .values(enableIds.map((permissionId) => ({ roleId, permissionId })))
+            .values(
+              enableIds.map((permissionId) => ({
+                roleId,
+                permissionId,
+                orgId,
+              })),
+            )
             .onConflictDoNothing({
               target: [
                 zuvyPermissionsRoles.roleId,
@@ -336,8 +430,8 @@ export class RbacPermissionService {
             .where(
               and(
                 eq(zuvyPermissionsRoles.roleId, roleId),
-                inArray(zuvyPermissionsRoles.permissionId, disableIds)
-              )
+                inArray(zuvyPermissionsRoles.permissionId, disableIds),
+              ),
             );
         }
 
@@ -361,5 +455,4 @@ export class RbacPermissionService {
       throw new InternalServerErrorException('Failed to assign permissions');
     }
   }
-
 }

--- a/src/rbac/rbac.service.ts
+++ b/src/rbac/rbac.service.ts
@@ -1,47 +1,87 @@
-import { Injectable, InternalServerErrorException, Logger, NotFoundException } from '@nestjs/common';
+import {
+  Injectable,
+  InternalServerErrorException,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
 import { db } from 'src/db/index';
 import { inArray, sql, eq, and } from 'drizzle-orm';
-import { userRoles, zuvyPermissions, zuvyPermissionsRoles, zuvyResources, zuvyRolePermissions, zuvyUserRoles, zuvyUserRolesAssigned } from 'drizzle/schema';
+import {
+  userRoles,
+  zuvyPermissions,
+  zuvyPermissionsRoles,
+  zuvyResources,
+  zuvyUserRoles,
+  zuvyUserRolesAssigned,
+} from 'drizzle/schema';
 import { ResourceList } from './utility';
 import { PermissionsAllocationService } from 'src/permissions/permissions.alloc.service';
 
 @Injectable()
 export class RbacService {
   constructor(
-    private readonly permissionAllocationService: PermissionsAllocationService
-  ){}
+    private readonly permissionAllocationService: PermissionsAllocationService,
+  ) {}
   private readonly logger = new Logger(RbacService.name);
 
-  async getAllPermissions(roleName: string[], targetPermissions: string[], resourceIds?: number): Promise<any> {
+  async getAllPermissions(
+    roleName: string[],
+    targetPermissions: string[],
+    orgId: number,
+  ): Promise<any> {
     try {
-      return await this.permissionAllocationService.getAllPermissions(roleName, targetPermissions);
-    }
-    catch (err) {
+      return await this.permissionAllocationService.getAllPermissions(
+        roleName,
+        targetPermissions,
+        orgId,
+      );
+    } catch (err) {
       this.logger.error('Error retrieving all permissions:', err);
-      throw new InternalServerErrorException('Failed to retrieve permissions');
+      throw err;
     }
   }
 
-    async getUserPermissionsByResource(userId: bigint, resourceId: number): Promise<any> {
-      try {
-        await this.permissionAllocationService.getUserPermissionsByResource(userId, resourceId);
-      } catch (err) {
-        this.logger.error(`Error getting user permissions for user ${userId} and resource ${resourceId}:`, err);
-        if (err instanceof NotFoundException) throw err;
-        throw new InternalServerErrorException('Failed to retrieve user permissions');
-      }
+  async getUserPermissionsByResource(
+    userId: bigint,
+    resourceId: number,
+    orgId: number,
+  ): Promise<any> {
+    try {
+      await this.permissionAllocationService.getUserPermissionsByResource(
+        userId,
+        resourceId,
+        orgId,
+      );
+    } catch (err) {
+      this.logger.error(
+        `Error getting user permissions for user ${userId} and resource ${resourceId}:`,
+        err,
+      );
+      if (err instanceof NotFoundException) throw err;
+      throw new InternalServerErrorException(
+        'Failed to retrieve user permissions',
+      );
     }
-  
-    async getUserPermissionsForMultipleResources(userId: bigint): Promise<any> {
-      try {
-        return await this.permissionAllocationService.getUserPermissionsForMultipleResources(userId);
-      } catch (err) {
-        this.logger.error(
-          `Error in getUserPermissionsForMultipleResources for user ${userId}:`,
-          err,
-        );
-        if (err instanceof NotFoundException) throw err;
-        throw new InternalServerErrorException('Failed to retrieve user permissions');
-      }
+  }
+
+  async getUserPermissionsForMultipleResources(
+    userId: bigint,
+    orgId: number,
+  ): Promise<any> {
+    try {
+      return await this.permissionAllocationService.getUserPermissionsForMultipleResources(
+        userId,
+        orgId,
+      );
+    } catch (err) {
+      this.logger.error(
+        `Error in getUserPermissionsForMultipleResources for user ${userId}:`,
+        err,
+      );
+      if (err instanceof NotFoundException) throw err;
+      throw new InternalServerErrorException(
+        'Failed to retrieve user permissions',
+      );
     }
+  }
 }


### PR DESCRIPTION
1. Restrict user management operations to specific organizations with proper validation
2. Enhance organization filtering with search term and management type filters
3. Enable public bootcamps (orgId null) for all users including unassociated ones
4. Add automatic synchronization of user details to POC records with transaction support
5. Fix searchTerm parameter handling in getAllBootcamps endpoint
6. Wherever the userTokens table was being used, I added zuvyuserOrganization in the classes service
7. scope permissions by organization ID
8. Added the orgId in the zuvyPermissionsRoles table.