### PR TITLE
Chore/org admin

### DIFF
--- a/src/controller/bootcamp/bootcamp.service.ts
+++ b/src/controller/bootcamp/bootcamp.service.ts
@@ -124,7 +124,10 @@ export class BootcampService {
         }
       }
 
-      let orgCondition = isNull(zuvyBootcamps.organizationId);
+      let orgCondition = or(
+        isNull(zuvyBootcamps.organizationId),
+        eq(zuvyBootcampType.type, 'Public'),
+      );
       if (filterOrgId) {
         orgCondition = or(
           orgCondition,
@@ -144,8 +147,31 @@ export class BootcampService {
           searchCondition = and(searchCondition, orgCondition);
         }
         query = db
-          .select()
+          .select({
+            id: zuvyBootcamps.id,
+            name: zuvyBootcamps.name,
+            description: zuvyBootcamps.description,
+            collaborator: zuvyBootcamps.collaborator,
+            coverImage: zuvyBootcamps.coverImage,
+            bootcampTopic: zuvyBootcamps.bootcampTopic,
+            startTime: zuvyBootcamps.startTime,
+            duration: zuvyBootcamps.duration,
+            language: zuvyBootcamps.language,
+            organizationId: zuvyBootcamps.organizationId,
+            createdAt: zuvyBootcamps.createdAt,
+            updatedAt: zuvyBootcamps.updatedAt,
+            version: zuvyBootcamps.version,
+            code: zuvyOrganizations.displayName,
+          })
           .from(zuvyBootcamps)
+          .leftJoin(
+            zuvyOrganizations,
+            eq(zuvyBootcamps.organizationId, zuvyOrganizations.id),
+          )
+          .leftJoin(
+            zuvyBootcampType,
+            eq(zuvyBootcamps.id, zuvyBootcampType.bootcampId),
+          )
           .where(searchCondition)
           .orderBy(desc(zuvyBootcamps.updatedAt))
           .limit(limit)
@@ -153,6 +179,10 @@ export class BootcampService {
         countQuery = db
           .select({ count: count(zuvyBootcamps.id) })
           .from(zuvyBootcamps)
+          .leftJoin(
+            zuvyBootcampType,
+            eq(zuvyBootcamps.id, zuvyBootcampType.bootcampId),
+          )
           .where(searchCondition);
       } else if (searchTermAsString) {
         const searchTokens = searchTermAsString.split(/\s+/); // Split by whitespace
@@ -167,8 +197,31 @@ export class BootcampService {
         }
 
         query = db
-          .select()
+          .select({
+            id: zuvyBootcamps.id,
+            name: zuvyBootcamps.name,
+            description: zuvyBootcamps.description,
+            collaborator: zuvyBootcamps.collaborator,
+            coverImage: zuvyBootcamps.coverImage,
+            bootcampTopic: zuvyBootcamps.bootcampTopic,
+            startTime: zuvyBootcamps.startTime,
+            duration: zuvyBootcamps.duration,
+            language: zuvyBootcamps.language,
+            organizationId: zuvyBootcamps.organizationId,
+            createdAt: zuvyBootcamps.createdAt,
+            updatedAt: zuvyBootcamps.updatedAt,
+            version: zuvyBootcamps.version,
+            code: zuvyOrganizations.displayName,
+          })
           .from(zuvyBootcamps)
+          .leftJoin(
+            zuvyOrganizations,
+            eq(zuvyBootcamps.organizationId, zuvyOrganizations.id),
+          )
+          .leftJoin(
+            zuvyBootcampType,
+            eq(zuvyBootcamps.id, zuvyBootcampType.bootcampId),
+          )
           .where(finalSearchCondition)
           .orderBy(desc(zuvyBootcamps.updatedAt))
           .limit(limit)
@@ -177,6 +230,10 @@ export class BootcampService {
         countQuery = db
           .select({ count: count(zuvyBootcamps.id) })
           .from(zuvyBootcamps)
+          .leftJoin(
+            zuvyBootcampType,
+            eq(zuvyBootcamps.id, zuvyBootcampType.bootcampId),
+          )
           .where(finalSearchCondition);
       } else if (roleName.includes('instructor')) {
         //first get all batches assigned to the instructor in zuvyBatches table then get all bootcampas from zuvyBootcamps table
@@ -200,6 +257,7 @@ export class BootcampService {
 
         let condition = or(
           isNull(zuvyBootcamps.organizationId),
+          eq(zuvyBootcampType.type, 'Public'),
           inArray(zuvyBootcamps.id, bootcampIds),
         );
         if (orgCondition) {
@@ -207,8 +265,31 @@ export class BootcampService {
         }
 
         query = db
-          .select()
+          .select({
+            id: zuvyBootcamps.id,
+            name: zuvyBootcamps.name,
+            description: zuvyBootcamps.description,
+            collaborator: zuvyBootcamps.collaborator,
+            coverImage: zuvyBootcamps.coverImage,
+            bootcampTopic: zuvyBootcamps.bootcampTopic,
+            startTime: zuvyBootcamps.startTime,
+            duration: zuvyBootcamps.duration,
+            language: zuvyBootcamps.language,
+            organizationId: zuvyBootcamps.organizationId,
+            createdAt: zuvyBootcamps.createdAt,
+            updatedAt: zuvyBootcamps.updatedAt,
+            version: zuvyBootcamps.version,
+            code: zuvyOrganizations.displayName,
+          })
           .from(zuvyBootcamps)
+          .leftJoin(
+            zuvyOrganizations,
+            eq(zuvyBootcamps.organizationId, zuvyOrganizations.id),
+          )
+          .leftJoin(
+            zuvyBootcampType,
+            eq(zuvyBootcamps.id, zuvyBootcampType.bootcampId),
+          )
           .where(condition)
           .orderBy(desc(zuvyBootcamps.updatedAt))
           .limit(limit)
@@ -217,9 +298,38 @@ export class BootcampService {
         countQuery = db
           .select({ count: count(zuvyBootcamps.id) })
           .from(zuvyBootcamps)
+          .leftJoin(
+            zuvyBootcampType,
+            eq(zuvyBootcamps.id, zuvyBootcampType.bootcampId),
+          )
           .where(condition);
       } else {
-        query = db.select().from(zuvyBootcamps);
+        query = db
+          .select({
+            id: zuvyBootcamps.id,
+            name: zuvyBootcamps.name,
+            description: zuvyBootcamps.description,
+            collaborator: zuvyBootcamps.collaborator,
+            coverImage: zuvyBootcamps.coverImage,
+            bootcampTopic: zuvyBootcamps.bootcampTopic,
+            startTime: zuvyBootcamps.startTime,
+            duration: zuvyBootcamps.duration,
+            language: zuvyBootcamps.language,
+            organizationId: zuvyBootcamps.organizationId,
+            createdAt: zuvyBootcamps.createdAt,
+            updatedAt: zuvyBootcamps.updatedAt,
+            version: zuvyBootcamps.version,
+            code: zuvyOrganizations.displayName,
+          })
+          .from(zuvyBootcamps)
+          .leftJoin(
+            zuvyOrganizations,
+            eq(zuvyBootcamps.organizationId, zuvyOrganizations.id),
+          )
+          .leftJoin(
+            zuvyBootcampType,
+            eq(zuvyBootcamps.id, zuvyBootcampType.bootcampId),
+          );
         if (orgCondition) {
           query = query.where(orgCondition);
         }
@@ -230,7 +340,11 @@ export class BootcampService {
 
         countQuery = db
           .select({ count: count(zuvyBootcamps.id) })
-          .from(zuvyBootcamps);
+          .from(zuvyBootcamps)
+          .leftJoin(
+            zuvyBootcampType,
+            eq(zuvyBootcamps.id, zuvyBootcampType.bootcampId),
+          );
         if (orgCondition) {
           countQuery = countQuery.where(orgCondition);
         }

--- a/src/controller/bootcamp/dto/bootcamp.dto.ts
+++ b/src/controller/bootcamp/dto/bootcamp.dto.ts
@@ -22,6 +22,15 @@ export class CreateBootcampDto {
   name: string;
 
   @ApiProperty({
+    type: Number,
+    example: 123,
+    required: true,
+  })
+  @IsNotEmpty()
+  @IsNumber()
+  organizationId: number;
+
+  @ApiProperty({
     type: String,
     example: 'Collaboration Name or https://example.com/logo.png',
     required: false,
@@ -47,16 +56,6 @@ export class CreateBootcampDto {
   @IsOptional()
   @IsNumber()
   duration?: number;
-
-  // add the orgId
-  @ApiProperty({
-    type: Number,
-    example: 123,
-    required: true,
-  })
-  @IsNotEmpty()
-  @IsNumber()
-  organizationId: number;
 }
 
 export class EditBootcampDto {

--- a/src/controller/users/users.controller.ts
+++ b/src/controller/users/users.controller.ts
@@ -166,11 +166,24 @@ export class UsersController {
     status: 500,
     description: 'Internal server error',
   })
+  @ApiQuery({
+    name: 'orgId',
+    required: true,
+    type: Number,
+    description: 'Organization ID to filter roles',
+  })
   @ApiBearerAuth('JWT-auth')
-  async getAllUserRoles(@Req() req): Promise<any> {
+  async getAllUserRoles(
+    @Req() req,
+    @Query('orgId', ParseIntPipe) orgId: number,
+  ): Promise<any> {
     try {
       const roleName = req.user[0]?.roles;
-      const result = await this.usersService.getAllUserRoles(roleName);
+      const result = await this.usersService.getAllUserRoles(
+        roleName,
+        false,
+        orgId,
+      );
       return result;
     } catch (error) {
       throw new HttpException(
@@ -195,11 +208,24 @@ export class UsersController {
     status: 500,
     description: 'Internal server error',
   })
+  @ApiQuery({
+    name: 'orgId',
+    required: true,
+    type: Number,
+    description: 'Organization ID to filter roles',
+  })
   @ApiBearerAuth('JWT-auth')
-  async getAllUserRolesNoFilter(@Req() req): Promise<any> {
+  async getAllUserRolesNoFilter(
+    @Req() req,
+    @Query('orgId', ParseIntPipe) orgId: number,
+  ): Promise<any> {
     try {
       const roleName = req.user[0]?.roles;
-      const result = await this.usersService.getAllUserRoles(roleName, true);
+      const result = await this.usersService.getAllUserRoles(
+        roleName,
+        true,
+        orgId,
+      );
       return result;
     } catch (error) {
       throw new HttpException(
@@ -302,8 +328,15 @@ export class UsersController {
     status: 500,
     description: 'Internal server error',
   })
+  @ApiQuery({
+    name: 'orgId',
+    required: true,
+    type: Number,
+    description: 'Organization ID to filter users',
+  })
   async getAllUsers(
     @Req() req, // Required parameter first
+    @Query('orgId', ParseIntPipe) orgIdQuery: number,
     @Query('limit') limit?: string, // Optional
     @Query('offset') offset?: string, // Optional
     @Query('searchTerm') searchTerm?: string, // Optional (default to '')
@@ -328,7 +361,7 @@ export class UsersController {
     }
 
     const roleName = req.user[0]?.roles;
-    const orgId = req.user[0]?.orgId;
+    const orgId = orgIdQuery || req.user[0]?.orgId;
     return this.usersService.getAllUsersWithRoles(
       roleName,
       limitNum,

--- a/src/controller/users/users.service.ts
+++ b/src/controller/users/users.service.ts
@@ -259,12 +259,16 @@ export class UsersService {
     }
   }
 
-  async getAllUserRoles(roleName: string, duplicate?: boolean): Promise<any> {
+  async getAllUserRoles(
+    roleName: string,
+    duplicate?: boolean,
+    orgId?: number,
+  ): Promise<any> {
     try {
       if (duplicate) {
         try {
           const result = await db.execute(
-            sql`SELECT * FROM main.zuvy_user_roles`,
+            sql`SELECT * FROM main.zuvy_user_roles WHERE org_id = ${orgId}`,
           );
           return {
             status: 'success',
@@ -280,11 +284,11 @@ export class UsersService {
       let query;
 
       if (roleName[0] === 'super admin') {
-        query = sql`SELECT * FROM main.zuvy_user_roles WHERE name != 'super admin'`;
+        query = sql`SELECT * FROM main.zuvy_user_roles WHERE name != 'super_admin' AND org_id = ${orgId}`;
       } else if (roleName[0] === 'admin') {
-        query = sql`SELECT * FROM main.zuvy_user_roles WHERE name NOT IN ('admin', 'super admin')`;
+        query = sql`SELECT * FROM main.zuvy_user_roles WHERE name NOT IN ('admin', 'super_admin') AND org_id = ${orgId}`;
       } else {
-        query = sql`SELECT * FROM main.zuvy_user_roles WHERE name NOT IN ('admin', 'super admin')`;
+        query = sql`SELECT * FROM main.zuvy_user_roles WHERE name NOT IN ('admin', 'super_admin') AND org_id = ${orgId}`;
       }
 
       const result = await db.execute(query);

--- a/src/notification/email/email.service.ts
+++ b/src/notification/email/email.service.ts
@@ -26,7 +26,7 @@ export class NotificationEmailService {
     template: string,
     data: any,
     providerName: string = 'ses',
-    config: any = {},
+    config?: any,
   ) {
     let provider: EmailProvider;
 

--- a/src/notification/email/providers/ses.provider.ts
+++ b/src/notification/email/providers/ses.provider.ts
@@ -11,7 +11,7 @@ export class SesProvider {
     AWS.config.update({
       accessKeyId: process.env.AWS_SUPPORT_ACCESS_KEY_ID,
       secretAccessKey: process.env.AWS_SUPPORT_ACCESS_SECRET_KEY,
-      region: 'ap-south-1',
+      region: process.env.AWS_REGION,
     });
 
     this.ses = new AWS.SES();
@@ -30,8 +30,8 @@ export class SesProvider {
           ToAddresses: [to],
         },
         Message: {
-          Subject: { Data: subject },
-          Body: { Text: { Data: body } },
+          Subject: { Data: subject, Charset: 'UTF-8' },
+          Body: { Text: { Data: body, Charset: 'UTF-8' } },
         },
       };
 

--- a/src/notification/email/providers/ses.provider.ts
+++ b/src/notification/email/providers/ses.provider.ts
@@ -22,16 +22,30 @@ export class SesProvider {
     body: string,
     config?: any,
   ): Promise<any> {
-    const info = await this.ses.sendEmail({
-      from:
-        config?.from ||
-        process.env.SUPPORT_EMAIL ||
-        '"Zuvy Support" <team@zuvy.org>',
-      to,
-      subject,
-      html: body,
-    });
+    try {
+      const emailParams = {
+        Source: 'team@zuvy.org',
+        Destination: {
+          ToAddresses: [to],
+        },
+        Message: {
+          Subject: {
+            Data: subject,
+          },
+          Body: {
+            Text: {
+              Data: body,
+            },
+          },
+        },
+      };
 
-    return info;
+      const info = await this.ses.sendEmail(emailParams);
+
+      return info;
+    } catch (error) {
+      this.logger.error(`Failed to send email via SES: ${error.message}`);
+      throw error;
+    }
   }
 }

--- a/src/notification/email/providers/ses.provider.ts
+++ b/src/notification/email/providers/ses.provider.ts
@@ -1,23 +1,19 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import * as nodemailer from 'nodemailer';
 import * as AWS from 'aws-sdk';
 @Injectable()
 export class SesProvider {
-  private transporter;
+  private ses: AWS.SES;
+  private readonly logger = new Logger(SesProvider.name);
 
   constructor() {
-    // Configure AWS SDK
     AWS.config.update({
       accessKeyId: process.env.AWS_SUPPORT_ACCESS_KEY_ID,
       secretAccessKey: process.env.AWS_SUPPORT_ACCESS_SECRET_KEY,
       region: process.env.AWS_REGION,
     });
 
-    const ses = new AWS.SES({ apiVersion: '2010-12-01' });
-
-    this.transporter = nodemailer.createTransport({
-      SES: ses,
-    });
+    this.ses = new AWS.SES({ apiVersion: '2010-12-01' });
   }
 
   async sendEmail(
@@ -26,7 +22,7 @@ export class SesProvider {
     body: string,
     config?: any,
   ): Promise<any> {
-    const info = await this.transporter.sendMail({
+    const info = await this.ses.sendEmail({
       from:
         config?.from ||
         process.env.SUPPORT_EMAIL ||

--- a/src/notification/email/providers/ses.provider.ts
+++ b/src/notification/email/providers/ses.provider.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import * as nodemailer from 'nodemailer';
 import * as AWS from 'aws-sdk';
+import { SendEmailRequest } from 'aws-sdk/clients/ses';
 @Injectable()
 export class SesProvider {
   private ses: AWS.SES;
@@ -10,10 +11,10 @@ export class SesProvider {
     AWS.config.update({
       accessKeyId: process.env.AWS_SUPPORT_ACCESS_KEY_ID,
       secretAccessKey: process.env.AWS_SUPPORT_ACCESS_SECRET_KEY,
-      region: process.env.AWS_REGION,
+      region: 'ap-south-1',
     });
 
-    this.ses = new AWS.SES({ apiVersion: '2010-12-01' });
+    this.ses = new AWS.SES();
   }
 
   async sendEmail(
@@ -23,24 +24,18 @@ export class SesProvider {
     config?: any,
   ): Promise<any> {
     try {
-      const emailParams = {
+      const emailParams: SendEmailRequest = {
         Source: 'team@zuvy.org',
         Destination: {
           ToAddresses: [to],
         },
         Message: {
-          Subject: {
-            Data: subject,
-          },
-          Body: {
-            Text: {
-              Data: body,
-            },
-          },
+          Subject: { Data: subject },
+          Body: { Text: { Data: body } },
         },
       };
 
-      const info = await this.ses.sendEmail(emailParams);
+      const info = await this.ses.sendEmail(emailParams).promise();
 
       return info;
     } catch (error) {

--- a/src/org/dto/create-org.dto.ts
+++ b/src/org/dto/create-org.dto.ts
@@ -17,14 +17,14 @@ export class CreateOrgDto {
   @IsNotEmpty()
   title: string;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     type: String,
     example: 'The display name of the organization',
-    required: true,
+    required: false,
   })
   @IsString()
-  @IsNotEmpty()
-  displayName: string;
+  @IsOptional()
+  displayName?: string;
 
   @ApiPropertyOptional({
     type: String,

--- a/src/org/org.service.ts
+++ b/src/org/org.service.ts
@@ -37,11 +37,135 @@ export class OrgService {
     private readonly userTokenService: UserTokensService,
   ) {}
 
+  private generateCode(title: string): string {
+    const words = title.split(' ');
+    if (words.length > 1) {
+      return words
+        .map((word) => word[0])
+        .join('')
+        .toUpperCase();
+    }
+    const capitals = title.match(/[A-Z]/g);
+    if (capitals && capitals.length > 1) {
+      return capitals.join('').toUpperCase();
+    }
+    return title.substring(0, 2).toUpperCase();
+  }
+
+  private async createDefaultRoles(tx: any, orgId: number) {
+    const defaultRoles = [
+      {
+        name: 'admin',
+        description: 'Organization Admin with full permissions',
+      },
+      { name: 'ops', description: 'Operations role' },
+      { name: 'instructor', description: 'Instructor role' },
+    ];
+
+    const createdRoles = await tx
+      .insert(zuvyUserRoles)
+      .values(
+        defaultRoles.map((role) => ({
+          ...role,
+          orgId,
+        })),
+      )
+      .returning();
+
+    const adminRole = createdRoles.find((r) => r.name === 'admin');
+
+    // Assign all permissions to the admin role
+    const allPermissions = await tx.select().from(zuvyPermissions);
+    if (allPermissions.length > 0 && adminRole) {
+      await tx.insert(zuvyPermissionsRoles).values(
+        allPermissions.map((permission) => ({
+          permissionId: permission.id,
+          roleId: adminRole.id,
+          orgId,
+        })),
+      );
+    }
+
+    return createdRoles;
+  }
+
+  async assignAdminToUser(
+    tx: any,
+    email: string,
+    name: string,
+    orgId: number,
+    adminRoleId: number,
+  ) {
+    let userId: number | bigint;
+    const [existingUser] = await tx
+      .select()
+      .from(users)
+      .where(eq(users.email, email))
+      .limit(1);
+
+    if (existingUser) {
+      userId = existingUser.id;
+    } else {
+      const [newUser] = await tx
+        .insert(users)
+        .values({ email, name })
+        .returning();
+      userId = newUser.id;
+    }
+
+    // Assign Admin Role if not already assigned for this org
+    const [existingAssignment] = await tx
+      .select()
+      .from(zuvyUserRolesAssigned)
+      .where(
+        and(
+          eq(zuvyUserRolesAssigned.userId, BigInt(userId)),
+          eq(zuvyUserRolesAssigned.roleId, adminRoleId),
+          eq(zuvyUserRolesAssigned.organizationId, orgId),
+        ),
+      )
+      .limit(1);
+
+    if (!existingAssignment) {
+      await tx.insert(zuvyUserRolesAssigned).values({
+        userId: userId,
+        roleId: adminRoleId,
+        organizationId: orgId,
+        createdAt: new Date().toISOString(),
+      });
+    }
+
+    // Link User to Organization
+    const [existingLink] = await tx
+      .select()
+      .from(zuvyUserOrganizations)
+      .where(
+        and(
+          eq(zuvyUserOrganizations.userId, Number(userId)),
+          eq(zuvyUserOrganizations.organizationId, orgId),
+        ),
+      )
+      .limit(1);
+
+    if (!existingLink) {
+      await tx.insert(zuvyUserOrganizations).values({
+        userId: Number(userId),
+        organizationId: orgId,
+        userEmail: email,
+      });
+    }
+
+    return userId;
+  }
+
   async createOrg(createOrgDto: CreateOrgDto) {
     try {
+      const displayName =
+        createOrgDto.displayName || this.generateCode(createOrgDto.title);
+
       const createOrgDtoValues = {
         title: createOrgDto.title,
-        displayName: createOrgDto.displayName,
+        displayName: displayName,
         logoUrl: createOrgDto.logoUrl || null,
         pocName: createOrgDto.pocName,
         pocEmail: createOrgDto.pocEmail,
@@ -63,89 +187,27 @@ export class OrgService {
           );
         }
 
-        // 2. Create org-scoped admin role
-        let createAdminRoleData = {
-          name: 'admin',
-          description: 'Organization Admin with full permissions',
-          orgId: newOrg.id,
-        };
-        const [adminRole] = await tx
-          .insert(zuvyUserRoles)
-          .values(createAdminRoleData)
-          .returning();
-        const adminRoleId = adminRole.id;
+        // 2. Create default roles and assign permissions to admin
+        const createdRoles = await this.createDefaultRoles(tx, newOrg.id);
+        const adminRoleId = createdRoles.find((r) => r.name === 'admin').id;
 
-        // 2a. Assign all permissions to the admin role
-        const allPermissions = await tx.select().from(zuvyPermissions);
-        if (allPermissions.length > 0) {
-          await tx.insert(zuvyPermissionsRoles).values(
-            allPermissions.map((permission) => ({
-              permissionId: permission.id,
-              roleId: adminRoleId,
-              orgId: newOrg.id,
-            })),
-          );
-        }
+        // 3. Process POC (Assign Admin Role)
+        await this.assignAdminToUser(
+          tx,
+          createOrgDto.pocEmail,
+          createOrgDto.pocName || 'POC',
+          newOrg.id,
+          adminRoleId,
+        );
 
-        // Helper to get or create user and assign role
-        const processUser = async (email: string, name: string) => {
-          let userId: number | bigint;
-          const [existingUser] = await tx
-            .select()
-            .from(users)
-            .where(eq(users.email, email))
-            .limit(1);
-
-          if (existingUser) {
-            userId = existingUser.id;
-          } else {
-            const [newUser] = await tx
-              .insert(users)
-              .values({ email, name })
-              .returning();
-            userId = newUser.id;
-          }
-
-          // Assign Admin Role if not already assigned for this org
-          const [existingRole] = await tx
-            .select()
-            .from(zuvyUserRolesAssigned)
-            .where(
-              and(
-                eq(zuvyUserRolesAssigned.userId, userId),
-                eq(zuvyUserRolesAssigned.roleId, adminRoleId),
-                eq(zuvyUserRolesAssigned.organizationId, newOrg.id),
-              ),
-            )
-            .limit(1);
-
-          const roleData = {
-            userId: userId,
-            roleId: adminRoleId,
-            organizationId: newOrg.id,
-            createdAt: new Date().toISOString(),
-          };
-          if (!existingRole) {
-            await tx.insert(zuvyUserRolesAssigned).values(roleData);
-          }
-
-          // Link User to Organization
-          let userData = {
-            userId: Number(userId),
-            organizationId: newOrg.id,
-            userEmail: email,
-          };
-          await tx.insert(zuvyUserOrganizations).values(userData);
-        };
-
-        // 3. Process POC
-        await processUser(createOrgDto.pocEmail, createOrgDto.pocName || 'POC');
-
-        // 4. Process Zuvy POC if managed
+        // 4. Process Zuvy POC (Assign Admin Role) if managed
         if (createOrgDto.isManagedByZuvy && createOrgDto.zuvyPocEmail) {
-          await processUser(
+          await this.assignAdminToUser(
+            tx,
             createOrgDto.zuvyPocEmail,
             createOrgDto.zuvyPocName || 'Zuvy POC',
+            newOrg.id,
+            adminRoleId,
           );
         }
 
@@ -155,10 +217,10 @@ export class OrgService {
       // 5. Send Email (After transaction)
       const magicLink = `${process.env.APP_BASE_URL}/org/getOrgById/${result.id}`;
       try {
-        const subject = `Welcome to Zuvy - Complete ${createOrgDto.displayName} Setup`;
+        const subject = `Welcome to Zuvy - Complete ${displayName} Setup`;
         const html = `
           <h1>Welcome to Zuvy!</h1>
-          <p>You have been invited to set up the organization <b>${createOrgDto.displayName}</b>.</p>
+          <p>You have been invited to set up the organization <b>${displayName}</b>.</p>
           <p>Please click the link below to complete your profile and organization details:</p>
           <a href="${magicLink}">Complete Setup</a>
           <p>If you did not request this, please ignore this email.</p>
@@ -184,10 +246,8 @@ export class OrgService {
           `❌ Failed to send email to ${createOrgDto.pocEmail}`,
         );
         this.logger.error(`Error message: ${emailError.message}`);
-        this.logger.error(`Error stack: ${emailError.stack}`);
 
         // Don't throw - org was created successfully, just email failed
-        // The user will see this in the logs
       }
 
       return {
@@ -253,7 +313,13 @@ export class OrgService {
       status: 'success',
       message: 'Organizations fetched successfully',
       statusCode: 200,
-      data: orgs,
+      data: orgs.map((org) => {
+        const { displayName, ...rest } = org;
+        return {
+          ...rest,
+          code: displayName,
+        };
+      }),
       meta: {
         total,
         page: pageNum,

--- a/src/permissions/permissions.alloc.service.ts
+++ b/src/permissions/permissions.alloc.service.ts
@@ -313,6 +313,13 @@ export class PermissionsAllocationService {
         };
       }
 
+      // 🔹 Super Admin Bypass: Return all requested permissions as true
+      if (roleNames.includes('super_admin')) {
+        const permissions: Record<string, boolean> = {};
+        targetPermissions.forEach((perm) => (permissions[perm] = true));
+        return { permissions };
+      }
+
       const roles = await db
         .select({ id: zuvyUserRoles.id })
         .from(zuvyUserRoles)


### PR DESCRIPTION
1. -Super Admin permissions are being handled as requested: bypassing checks and setting all permissions to true
2. - Refactor OrgService.createOrg to automatically create default roles (admin, ops, instructor).
3. - Implement refined organization code generation logic (e.g., extracting uppercase letters for "NG").
4. - Assign admin role and link POC/Zuvy POC to organizations upon creation.
5. - Update BootcampService to support 'Public' visibility, allowing cross-org access to courses.
6. - Enforce mandatory orgId filtering for roles and users API endpoints.
7. - Standardize organization displayName as 'code' in API responses.
8. - Simplify Bootcamp and Organization creation DTOs.
