### PR TITLE
fix the internal server error

### DIFF
--- a/src/rbac/rbac.controller.ts
+++ b/src/rbac/rbac.controller.ts
@@ -381,7 +381,7 @@ export class RbacController {
   }
 
   @Delete('permissions/:id')
-  //   @RequirePermissions('delete_permission')
+  //   @RequirePermissions('delete_permission')//
   @ApiOperation({
     summary: 'Delete a permission by id',
     description: 'Deletes a permission record by its numeric id',

--- a/src/rbac/rbac.controller.ts
+++ b/src/rbac/rbac.controller.ts
@@ -381,7 +381,7 @@ export class RbacController {
   }
 
   @Delete('permissions/:id')
-  //   @RequirePermissions('delete_permission')//
+  //   @RequirePermissions('delete_permission')
   @ApiOperation({
     summary: 'Delete a permission by id',
     description: 'Deletes a permission record by its numeric id',

--- a/src/rbac/rbac.controller.ts
+++ b/src/rbac/rbac.controller.ts
@@ -210,7 +210,9 @@ export class RbacController {
     @Req() req,
   ): Promise<any> {
     try {
-      const orgId = req.user[0]?.orgId;
+      const orgId =
+        assignPermissionsDto.orgId ??
+        (req.user[0]?.orgId ? parseInt(req.user[0].orgId) : undefined);
       const result = await this.rbacPermissionService.assignPermissionsToRole(
         assignPermissionsDto,
         orgId,

--- a/src/rbac/rbac.permission.service.ts
+++ b/src/rbac/rbac.permission.service.ts
@@ -1,6 +1,7 @@
 import {
   BadRequestException,
   ConflictException,
+  HttpException,
   Injectable,
   InternalServerErrorException,
   Logger,
@@ -475,6 +476,7 @@ export class RbacPermissionService {
       });
     } catch (error) {
       this.logger.error('Error in assignPermissionsToRole:', error);
+      if (error instanceof HttpException) throw error;
       throw new InternalServerErrorException('Failed to assign permissions');
     }
   }


### PR DESCRIPTION
**fix: resolve 500 error in assign permissions to role endpoint**

1. Re-throw HttpException in service catch block so proper 404/400 errors reach the client
2. Fix null orgId by reading from request body (dto.orgId) with fallback to JWT user orgId.