### PR TITLE
 restrict instructor visibility to assigned batches & fix DTO

### DIFF
--- a/src/auth/strategies/jwt.strategy.ts
+++ b/src/auth/strategies/jwt.strategy.ts
@@ -4,7 +4,6 @@ import { ExtractJwt, Strategy } from 'passport-jwt';
 import { AuthService } from '../auth.service';
 import { Request } from 'express';
 import { db } from 'src/db';
-import { sansaarUserRoles } from '../../../drizzle/schema';
 import { eq } from 'drizzle-orm';
 let { GOOGLE_CLIENT_ID, GOOGLE_SECRET, GOOGLE_REDIRECT_URI, JWT_SECRET_KEY } =
   process.env;

--- a/src/controller/batches/batch.controller.ts
+++ b/src/controller/batches/batch.controller.ts
@@ -14,6 +14,7 @@ import {
   Req,
   UseGuards,
   UseInterceptors,
+  ForbiddenException,
 } from '@nestjs/common';
 import { BatchesService } from './batch.service';
 import {
@@ -49,10 +50,26 @@ export class BatchesController {
   @ApiOperation({ summary: 'Get the batch by id' })
   @ApiBearerAuth('JWT-auth')
   // @ApiQuery({ name: 'students', required: false, type: Boolean, description: 'Optional content flag' })
-  async getBatchById(@Param('id') id: number): Promise<object> {
+  async getBatchById(
+    @Param('id') id: number,
+    @Req() req: any,
+  ): Promise<object> {
     const [err, res] = await this.batchService.getBatchById(id);
     if (err) {
       throw new BadRequestException(err);
+    }
+
+    const user = req.user;
+    const isInstructor = user.roles.includes('instructor');
+    const isAdmin =
+      user.roles.includes('admin') || user.roles.includes('super_admin');
+
+    if (isInstructor && !isAdmin) {
+      if (res['batch'].instructorId !== Number(user.id)) {
+        throw new ForbiddenException(
+          'You are not authorized to view this batch',
+        );
+      }
     }
     return res;
   }

--- a/src/controller/batches/batch.service.ts
+++ b/src/controller/batches/batch.service.ts
@@ -1,8 +1,9 @@
 import { Injectable } from '@nestjs/common';
 import {
-  zuvyBatches,
   users,
-  sansaarUserRoles,
+  zuvyBatches,
+  zuvyUserRoles,
+  zuvyUserRolesAssigned,
   zuvyBatchEnrollments,
   zuvyStudentAttendance,
   zuvyStudentAttendanceRecords,
@@ -10,7 +11,7 @@ import {
   zuvyBootcamps,
 } from '../../../drizzle/schema';
 import { db } from '../../db/index';
-import { eq, ilike, inArray, or, sql, and } from 'drizzle-orm';
+import { eq, ilike, inArray, or, sql, and, not, isNull } from 'drizzle-orm';
 import { log } from 'console';
 import { PatchBatchDto, BatchDto } from './dto/batch.dto';
 import { helperVariable } from 'src/constants/helper';
@@ -102,34 +103,50 @@ export class BatchesService {
         ];
       }
 
-      // Try to ensure instructor role exists but do not block on failure
+      // RBAC role assignment for the instructor
       try {
-        const instructorRoles = await db
-          .select({ role: sansaarUserRoles.role })
-          .from(sansaarUserRoles)
-          .where(eq(sansaarUserRoles.userId, Number(user[0].id)));
-        const hasInstructorRole = instructorRoles.some(
-          (r) => r.role === helperVariable.instructor,
-        );
-        if (!hasInstructorRole) {
-          try {
-            await db
-              .insert(sansaarUserRoles)
-              .values({
-                userId: Number(user[0].id),
-                role: helperVariable.instructor,
-                createdAt: new Date().toISOString(),
-              } as any)
-              .returning();
-          } catch (err) {
-            console.log(
-              'Failed to assign instructor role:',
-              err?.message || err,
-            );
+        const bootcamp = await db.query.zuvyBootcamps.findFirst({
+          where: eq(zuvyBootcamps.id, batch.bootcampId),
+        });
+        const orgId = bootcamp?.organizationId;
+
+        const instructorRole = await db
+          .select({ id: zuvyUserRoles.id })
+          .from(zuvyUserRoles)
+          .where(
+            and(
+              eq(sql`lower(${zuvyUserRoles.name})`, 'instructor'),
+              isNull(zuvyUserRoles.orgId),
+            ),
+          )
+          .limit(1);
+
+        const instructorRoleId = instructorRole[0]?.id;
+
+        if (instructorRoleId && user[0]?.id) {
+          const instructorUserId = BigInt(user[0].id);
+          const existingAssignment =
+            await db.query.zuvyUserRolesAssigned.findFirst({
+              where: and(
+                eq(zuvyUserRolesAssigned.userId, instructorUserId),
+                eq(zuvyUserRolesAssigned.roleId, instructorRoleId),
+                orgId
+                  ? eq(zuvyUserRolesAssigned.organizationId, orgId)
+                  : isNull(zuvyUserRolesAssigned.organizationId),
+              ),
+            });
+
+          if (!existingAssignment) {
+            let userData = {
+              userId: instructorUserId,
+              roleId: instructorRoleId,
+              organizationId: orgId || null,
+            };
+            await db.insert(zuvyUserRolesAssigned).values(userData);
           }
         }
       } catch (err) {
-        console.log('Error checking instructor role:', err?.message || err);
+        console.error('Failed to assign instructor role:', err);
       }
 
       // Build batch object
@@ -321,15 +338,21 @@ export class BatchesService {
         .from(zuvyBatchEnrollments)
         .where(eq(zuvyBatchEnrollments.batchId, id));
 
-      const batchInstructor = await db
-        .select({ id: users.id, email: users.email, name: users.name })
-        .from(users)
-        .where(eq(users.id, BigInt(data[0].instructorId)))
-        .limit(1);
-      const instructorName =
-        batchInstructor.length > 0 ? batchInstructor[0].name : null;
-      const instructorEmail =
-        batchInstructor.length > 0 ? batchInstructor[0].email : null;
+      const instructorId = data[0].instructorId;
+      let instructorName = null;
+      let instructorEmail = null;
+
+      if (instructorId) {
+        const batchInstructor = await db
+          .select({ id: users.id, email: users.email, name: users.name })
+          .from(users)
+          .where(eq(users.id, BigInt(instructorId)))
+          .limit(1);
+        if (batchInstructor.length > 0) {
+          instructorName = batchInstructor[0].name;
+          instructorEmail = batchInstructor[0].email;
+        }
+      }
       data[0]['instructorName'] = instructorName;
       data[0]['instructorEmail'] = instructorEmail;
       // Ensure start/end dates are present in returned batch object and normalized
@@ -438,40 +461,55 @@ export class BatchesService {
         const userObj = userRes[0];
         instructorEmailToReturn = userObj.email;
 
+        // RBAC role assignment for the NEW instructor
         try {
-          const instructorRoles = await db
-            .select({ role: sansaarUserRoles.role })
-            .from(sansaarUserRoles)
-            .where(eq(sansaarUserRoles.userId, Number(userObj.id)));
-          const hasInstructorRole = instructorRoles.some(
-            (r) => r.role === helperVariable.instructor,
-          );
-          if (!hasInstructorRole) {
-            // attempt assigning role but do not block update if this fails
-            try {
-              await db
-                .insert(sansaarUserRoles)
-                .values({
-                  userId: Number(userObj.id),
-                  role: helperVariable.instructor,
-                  createdAt: new Date().toISOString(),
-                } as any)
-                .returning();
-            } catch (roleErr) {
-              console.log(
-                'Failed to assign instructor role:',
-                roleErr?.message || roleErr,
-              );
+          const bootcamp = await db.query.zuvyBootcamps.findFirst({
+            where: eq(zuvyBootcamps.id, batchOld[0].bootcampId),
+          });
+          const orgId = bootcamp?.organizationId;
+
+          const instructorRole = await db
+            .select({ id: zuvyUserRoles.id })
+            .from(zuvyUserRoles)
+            .where(
+              and(
+                eq(sql`lower(${zuvyUserRoles.name})`, 'instructor'),
+                isNull(zuvyUserRoles.orgId),
+              ),
+            )
+            .limit(1);
+
+          const instructorRoleId = instructorRole[0]?.id;
+
+          if (instructorRoleId && userObj?.id) {
+            const instructorUserId = BigInt(userObj.id);
+            const existingAssignment =
+              await db.query.zuvyUserRolesAssigned.findFirst({
+                where: and(
+                  eq(zuvyUserRolesAssigned.userId, instructorUserId),
+                  eq(zuvyUserRolesAssigned.roleId, instructorRoleId),
+                  orgId
+                    ? eq(zuvyUserRolesAssigned.organizationId, orgId)
+                    : isNull(zuvyUserRolesAssigned.organizationId),
+                ),
+              });
+
+            if (!existingAssignment) {
+              let userData = {
+                userId: instructorUserId,
+                roleId: instructorRoleId,
+                organizationId: orgId || null,
+              };
+              await db.insert(zuvyUserRolesAssigned).values(userData);
             }
           }
-        } catch (roleCheckErr) {
-          console.log(
-            'Error checking/assigning instructor role:',
-            roleCheckErr?.message || roleCheckErr,
-          );
+        } catch (roleErr) {
+          console.error('Failed to assign new instructor role:', roleErr);
         }
 
-        batchValue.instructorId = Number(userObj.id);
+        if (userObj?.id) {
+          batchValue.instructorId = Number(userObj.id);
+        }
       }
 
       // If instructorEmail wasn't provided, keep existing instructorId unchanged by not including it in batchValue
@@ -529,6 +567,106 @@ export class BatchesService {
         .where(eq(zuvyBootcamps.id, updated.bootcampId))
         .limit(1);
       const bootcampName = courseRes[0]?.name || '';
+
+      // Role removal logic for previous instructor(s) using RBAC
+      if (
+        batch.instructorEmail &&
+        batchOld[0].instructorId !== batchValue.instructorId
+      ) {
+        const potentialPrevIds = new Set<number>();
+        if (batchOld[0].instructorId) {
+          potentialPrevIds.add(batchOld[0].instructorId);
+        }
+
+        // If previousInstructorEmail is explicitly provided, include that user for role check
+        if (batch.previousInstructorEmail) {
+          try {
+            const prevUser = await db
+              .select({ id: users.id })
+              .from(users)
+              .where(eq(users.email, batch.previousInstructorEmail))
+              .limit(1);
+            if (prevUser.length > 0) {
+              potentialPrevIds.add(Number(prevUser[0].id));
+            }
+          } catch (err) {
+            console.error('Failed to find previous instructor by email:', err);
+          }
+        }
+
+        // Don't remove role from the NEW instructor if they were somehow in the previous set
+        if (batchValue.instructorId) {
+          potentialPrevIds.delete(batchValue.instructorId);
+        }
+
+        for (const previousInstructorId of potentialPrevIds) {
+          try {
+            const bootcampRefId = batchOld[0].bootcampId;
+            const bootcamp = await db.query.zuvyBootcamps.findFirst({
+              where: eq(zuvyBootcamps.id, bootcampRefId),
+            });
+            const orgId = bootcamp?.organizationId;
+
+            // Count how many other batches this user has in this organization
+            const otherBatchesInOrg = await db
+              .select({ count: sql`count(*)` })
+              .from(zuvyBatches)
+              .innerJoin(
+                zuvyBootcamps,
+                eq(zuvyBatches.bootcampId, zuvyBootcamps.id),
+              )
+              .where(
+                and(
+                  eq(zuvyBatches.instructorId, previousInstructorId),
+                  orgId
+                    ? eq(zuvyBootcamps.organizationId, orgId)
+                    : isNull(zuvyBootcamps.organizationId),
+                  not(eq(zuvyBatches.id, id)),
+                ),
+              );
+
+            const otherBatchesCount = Number(otherBatchesInOrg[0].count);
+
+            if (otherBatchesCount === 0) {
+              const instructorRole = await db
+                .select({ id: zuvyUserRoles.id })
+                .from(zuvyUserRoles)
+                .where(
+                  and(
+                    eq(sql`lower(${zuvyUserRoles.name})`, 'instructor'),
+                    isNull(zuvyUserRoles.orgId),
+                  ),
+                )
+                .limit(1);
+
+              const instructorRoleId = instructorRole[0]?.id;
+
+              if (instructorRoleId) {
+                const prevInstructorUserId = BigInt(previousInstructorId);
+                console.log(
+                  `Removing instructor role for user ID: ${previousInstructorId} in Org: ${orgId}`,
+                );
+                await db
+                  .delete(zuvyUserRolesAssigned)
+                  .where(
+                    and(
+                      eq(zuvyUserRolesAssigned.userId, prevInstructorUserId),
+                      eq(zuvyUserRolesAssigned.roleId, instructorRoleId),
+                      orgId
+                        ? eq(zuvyUserRolesAssigned.organizationId, orgId)
+                        : isNull(zuvyUserRolesAssigned.organizationId),
+                    ),
+                  );
+              }
+            }
+          } catch (removeErr) {
+            console.error(
+              `Failed to remove instructor role for User ${previousInstructorId}:`,
+              removeErr,
+            );
+          }
+        }
+      }
 
       return [
         null,

--- a/src/controller/batches/dto/batch.dto.ts
+++ b/src/controller/batches/dto/batch.dto.ts
@@ -1,4 +1,15 @@
-import { IsString, IsNotEmpty, IsOptional, IsArray, ValidateNested, IsEmail, IsNumber, IsBoolean, ArrayNotEmpty, IsDateString } from 'class-validator';
+import {
+  IsString,
+  IsNotEmpty,
+  IsOptional,
+  IsArray,
+  ValidateNested,
+  IsEmail,
+  IsNumber,
+  IsBoolean,
+  ArrayNotEmpty,
+  IsDateString,
+} from 'class-validator';
 import { ApiProperty, ApiResponseProperty, ApiResponse } from '@nestjs/swagger';
 
 export class BatchDto {
@@ -42,7 +53,7 @@ export class BatchDto {
     type: String,
     example: '2025-09-20',
     required: false,
-    description: 'Optional start date for the batch (ISO date string)'
+    description: 'Optional start date for the batch (ISO date string)',
   })
   @IsOptional()
   @IsDateString()
@@ -52,7 +63,7 @@ export class BatchDto {
     type: String,
     example: '2025-12-20',
     required: false,
-    description: 'Optional end date for the batch (ISO date string)'
+    description: 'Optional end date for the batch (ISO date string)',
   })
   @IsOptional()
   @IsDateString()
@@ -71,7 +82,7 @@ export class BatchDto {
     type: String,
     example: 'Ongoing',
     required: false,
-    description: 'Optional status of the batch (e.g. Ongoing, Completed)'
+    description: 'Optional status of the batch (e.g. Ongoing, Completed)',
   })
   @IsOptional()
   @IsString()
@@ -118,7 +129,7 @@ export class PatchBatchDto {
     type: String,
     example: '2025-09-20',
     required: false,
-    description: 'Optional start date for the batch (ISO date string)'
+    description: 'Optional start date for the batch (ISO date string)',
   })
   @IsOptional()
   @IsDateString()
@@ -128,7 +139,7 @@ export class PatchBatchDto {
     type: String,
     example: '2025-12-20',
     required: false,
-    description: 'Optional end date for the batch (ISO date string)'
+    description: 'Optional end date for the batch (ISO date string)',
   })
   @IsOptional()
   @IsDateString()
@@ -138,9 +149,19 @@ export class PatchBatchDto {
     type: String,
     example: 'Ongoing',
     required: false,
-    description: 'Optional status of the batch (e.g. Ongoing, Completed)'
+    description: 'Optional status of the batch (e.g. Ongoing, Completed)',
   })
   @IsOptional()
   @IsString()
   status?: string;
+
+  @ApiProperty({
+    type: String,
+    example: 'oldinstructor@gmail.com',
+    required: false,
+    description: 'Optional previous instructor email for role management',
+  })
+  @IsOptional()
+  @IsEmail()
+  previousInstructorEmail?: string;
 }

--- a/src/controller/bootcamp/bootcamp.controller.ts
+++ b/src/controller/bootcamp/bootcamp.controller.ts
@@ -285,12 +285,14 @@ export class BootcampController {
   ): Promise<object> {
     const roleName = req.user[0]?.roles;
     const orgId = req.user[0]?.orgId;
+    const userId = req.user[0]?.id;
     const [err, res] = await this.bootcampService.getBatchByIdBootcamp(
       bootcamp_id,
       roleName,
       limit,
       offset,
       orgId,
+      userId,
     );
     if (err) {
       throw new BadRequestException(err);
@@ -310,10 +312,15 @@ export class BootcampController {
   async searchBatchesByName(
     @Param('bootcamp_id') bootcamp_id: number,
     @Query('searchTerm') searchTerm: string,
+    @Req() req,
   ): Promise<object> {
+    const roleName = req.user[0]?.roles;
+    const userId = req.user[0]?.id;
     const [err, res] = await this.bootcampService.searchBatchByIdBootcamp(
       bootcamp_id,
       searchTerm,
+      roleName,
+      userId,
     );
     if (err) {
       throw new BadRequestException(err);

--- a/src/controller/bootcamp/bootcamp.service.ts
+++ b/src/controller/bootcamp/bootcamp.service.ts
@@ -840,6 +840,7 @@ export class BootcampService {
     limit: number,
     offset: number,
     orgId: number,
+    userId: number,
   ): Promise<any> {
     try {
       // sanitize pagination parameters
@@ -852,6 +853,15 @@ export class BootcampService {
 
       // build query using a loose-typed builder to avoid TS generic reassign issues
       // select explicit columns to avoid referencing columns that may not exist in some DB schemas
+      let baseConditions = [eq(zuvyBatches.bootcampId, bootcamp_id)];
+      if (
+        roleName.includes('instructor') &&
+        !roleName.includes('admin') &&
+        !roleName.includes('super_admin')
+      ) {
+        baseConditions.push(eq(zuvyBatches.instructorId, userId));
+      }
+
       const baseQuery: any = db
         .select({
           id: zuvyBatches.id,
@@ -866,7 +876,7 @@ export class BootcampService {
           endDate: zuvyBatches.endDate,
         })
         .from(zuvyBatches)
-        .where(eq(zuvyBatches.bootcampId, bootcamp_id));
+        .where(and(...baseConditions));
       let queryBuilder: any = baseQuery;
       if (limitNum !== undefined) queryBuilder = queryBuilder.limit(limitNum);
       if (offsetNum !== undefined)
@@ -877,7 +887,7 @@ export class BootcampService {
       const totalCountQuery = await db
         .select({ count: count(zuvyBatches.id) })
         .from(zuvyBatches)
-        .where(eq(zuvyBatches.bootcampId, bootcamp_id));
+        .where(and(...baseConditions));
       const totalCount = totalCountQuery[0]?.count || 0;
       const totalPages =
         limitNum && limitNum > 0 ? Math.ceil(totalCount / limitNum) : 1;
@@ -950,8 +960,21 @@ export class BootcampService {
   async searchBatchByIdBootcamp(
     bootcamp_id: number,
     searchTerm: string,
+    roleName: string[],
+    userId: number,
   ): Promise<any> {
     try {
+      let baseConditions = [
+        sql`${zuvyBatches.bootcampId}=${bootcamp_id} AND (LOWER(${zuvyBatches.name}) LIKE ${searchTerm.toLowerCase()} || '%')`,
+      ];
+      if (
+        roleName.includes('instructor') &&
+        !roleName.includes('admin') &&
+        !roleName.includes('super_admin')
+      ) {
+        baseConditions.push(eq(zuvyBatches.instructorId, userId));
+      }
+
       const batchesData = await db
         .select({
           id: zuvyBatches.id,
@@ -966,9 +989,7 @@ export class BootcampService {
           endDate: zuvyBatches.endDate,
         })
         .from(zuvyBatches)
-        .where(
-          sql`${zuvyBatches.bootcampId}=${bootcamp_id} AND (LOWER(${zuvyBatches.name}) LIKE ${searchTerm.toLowerCase()} || '%')`,
-        );
+        .where(and(...baseConditions));
 
       const promises = batchesData.map(async (batch) => {
         const userEnrolled = await db


### PR DESCRIPTION
1.  Remove instructor role from previous instructor when batch instructor is updated
2.  Accept previousInstructorEmail and newInstructorEmail in API payload
3.  Ensure role is updated correctly in zuvyUserRolesAssigned table
4.  Clarify behavior for instructor visibility across global courses
5.  Restrict instructors from viewing batches of other instructors
