### PR TITLE
Feat/student and mentor dashboard

### DIFF
--- a/src/controller/mentor-slot/dto/reschedule.dto.ts
+++ b/src/controller/mentor-slot/dto/reschedule.dto.ts
@@ -1,9 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { IsNumber, IsString, MinLength } from 'class-validator';
 
 export class ProposeRescheduleDto {
-  @IsNumber()
-  newSlotId: number;
-
+  @ApiProperty({
+    example: 'I have a scheduling conflict and need a different time.',
+    description: 'Reason for requesting the reschedule',
+  })
   @IsString()
   @MinLength(10)
   reason: string;

--- a/src/controller/mentor-slot/mentor-slot.controller.ts
+++ b/src/controller/mentor-slot/mentor-slot.controller.ts
@@ -11,7 +11,7 @@ import {
   UseGuards,
   Query,
 } from '@nestjs/common';
-import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiBody, ApiTags } from '@nestjs/swagger';
 import { MentorSlotService } from './mentor-slot.service';
 import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
 import { BookSlotDto } from './dto/book-slot.dto';
@@ -60,12 +60,17 @@ export class MentorSlotController {
   ========================================================================== */
 
   @Post(':bookingId/reschedule')
+  @ApiBody({ type: ProposeRescheduleDto })
   async proposeReschedule(
     @Param('bookingId', ParseIntPipe) bookingId: number,
     @Query('slotId') slotId: number,
-    @Body('reason') reason: string,
+    @Body() body: ProposeRescheduleDto,
   ) {
-    return this.mentorSlotService.proposeReschedule(bookingId, slotId, reason);
+    return this.mentorSlotService.proposeReschedule(
+      bookingId,
+      slotId,
+      body.reason,
+    );
   }
 
   /* ==========================================================================

--- a/src/controller/mentor-slot/session/session.controller.ts
+++ b/src/controller/mentor-slot/session/session.controller.ts
@@ -5,12 +5,14 @@ import {
   ParseIntPipe,
   Req,
   UseGuards,
+  Query,
 } from '@nestjs/common';
 import {
   ApiBearerAuth,
   ApiTags,
   ApiOperation,
   ApiParam,
+  ApiQuery,
   ApiResponse,
 } from '@nestjs/swagger';
 
@@ -31,13 +33,34 @@ export class SessionController {
   @ApiOperation({
     summary: 'Get sessions booked by the current student',
   })
-  @ApiResponse({
-    status: 200,
-    description: 'List of student sessions',
+  @ApiQuery({
+    name: 'filter',
+    required: false,
+    enum: ['all', 'upcoming', 'completed', 'cancelled'],
+  })
+  @ApiQuery({
+    name: 'limit',
+    required: false,
+    type: Number,
+  })
+  @ApiQuery({
+    name: 'offset',
+    required: false,
+    type: Number,
   })
   @Get('my')
-  async getMySessions(@Req() req) {
-    return this.sessionService.getStudentSessions(BigInt(req.user[0].id));
+  async getMySessions(
+    @Req() req,
+    @Query('filter') filter?: string,
+    @Query('limit') limit = 10,
+    @Query('offset') offset = 0,
+  ) {
+    return this.sessionService.getStudentSessions(
+      BigInt(req.user[0].id),
+      filter,
+      Number(limit),
+      Number(offset),
+    );
   }
 
   /* ==========================================================================
@@ -51,9 +74,34 @@ export class SessionController {
     status: 200,
     description: 'List of mentor sessions',
   })
+  @ApiQuery({
+    name: 'filter',
+    required: false,
+    enum: ['all', 'upcoming', 'reschedule', 'completed'],
+  })
+  @ApiQuery({
+    name: 'limit',
+    required: false,
+    type: Number,
+  })
+  @ApiQuery({
+    name: 'offset',
+    required: false,
+    type: Number,
+  })
   @Get('mentor/my')
-  async getMentorSessions(@Req() req) {
-    return this.sessionService.getMentorSessions(BigInt(req.user[0].id));
+  async getMentorSessions(
+    @Req() req,
+    @Query('filter') filter?: string,
+    @Query('limit') limit = 10,
+    @Query('offset') offset = 0,
+  ) {
+    return this.sessionService.getMentorSessions(
+      BigInt(req.user[0].id),
+      filter,
+      Number(limit),
+      Number(offset),
+    );
   }
 
   /* ==========================================================================

--- a/src/controller/mentor-slot/session/session.service.ts
+++ b/src/controller/mentor-slot/session/session.service.ts
@@ -5,9 +5,14 @@ import {
 } from '@nestjs/common';
 
 import { db } from '../../../db';
-import { users, zuvyMentorSlotBooking } from '../../../../drizzle/schema';
+import {
+  users,
+  zuvyMentorSlotAvailability,
+  zuvyMentorSlotBooking,
+} from '../../../../drizzle/schema';
 
-import { eq } from 'drizzle-orm';
+import { and, eq, desc } from 'drizzle-orm';
+import { sl } from 'zod/v4/locales';
 
 @Injectable()
 export class SessionService {
@@ -15,30 +20,110 @@ export class SessionService {
      STUDENT SESSIONS
   ========================================================================== */
 
-  async getStudentSessions(userId: bigint) {
-    return db
+  async getStudentSessions(
+    userId: bigint,
+    filter = 'all',
+    limit = 10,
+    offset = 0,
+  ) {
+    const conditions = [eq(zuvyMentorSlotBooking.studentUserId, userId)];
+
+    if (filter === 'upcoming') {
+      conditions.push(
+        eq(zuvyMentorSlotBooking.sessionLifecycleState, 'SCHEDULED'),
+      );
+    }
+
+    if (filter === 'completed') {
+      conditions.push(
+        eq(zuvyMentorSlotBooking.sessionLifecycleState, 'COMPLETED'),
+      );
+    }
+
+    if (filter === 'cancelled') {
+      conditions.push(eq(zuvyMentorSlotBooking.status, 'cancelled'));
+    }
+
+    const data = await db
       .select({
         booking: zuvyMentorSlotBooking,
         mentorName: users.name,
+        slotStart: zuvyMentorSlotAvailability.slotStartDateTime,
+        slotEnd: zuvyMentorSlotAvailability.slotEndDateTime,
       })
       .from(zuvyMentorSlotBooking)
+
       .leftJoin(users, eq(users.id, zuvyMentorSlotBooking.mentorUserId))
-      .where(eq(zuvyMentorSlotBooking.studentUserId, userId));
+
+      .leftJoin(
+        zuvyMentorSlotAvailability,
+        eq(
+          zuvyMentorSlotAvailability.id,
+          zuvyMentorSlotBooking.slotAvailabilityId,
+        ),
+      )
+
+      .where(and(...conditions))
+      .orderBy(desc(zuvyMentorSlotBooking.bookedAt))
+      .limit(limit)
+      .offset(offset);
+
+    return data;
   }
 
   /* ==========================================================================
      MENTOR SESSIONS
   ========================================================================== */
 
-  async getMentorSessions(userId: bigint) {
-    return db
+  async getMentorSessions(
+    userId: bigint,
+    filter = 'all',
+    limit = 10,
+    offset = 0,
+  ) {
+    const conditions = [eq(zuvyMentorSlotBooking.mentorUserId, userId)];
+
+    if (filter === 'upcoming') {
+      conditions.push(
+        eq(zuvyMentorSlotBooking.sessionLifecycleState, 'SCHEDULED'),
+      );
+    }
+
+    if (filter === 'completed') {
+      conditions.push(
+        eq(zuvyMentorSlotBooking.sessionLifecycleState, 'COMPLETED'),
+      );
+    }
+
+    if (filter === 'reschedule') {
+      conditions.push(eq(zuvyMentorSlotBooking.rescheduleStatus, 'pending'));
+    }
+
+    const data = await db
       .select({
         booking: zuvyMentorSlotBooking,
         studentName: users.name,
+        slotStart: zuvyMentorSlotAvailability.slotStartDateTime,
+        slotEnd: zuvyMentorSlotAvailability.slotEndDateTime,
       })
       .from(zuvyMentorSlotBooking)
+
       .leftJoin(users, eq(users.id, zuvyMentorSlotBooking.studentUserId))
-      .where(eq(zuvyMentorSlotBooking.mentorUserId, userId));
+
+      .leftJoin(
+        zuvyMentorSlotAvailability,
+        eq(
+          zuvyMentorSlotAvailability.id,
+          zuvyMentorSlotBooking.slotAvailabilityId,
+        ),
+      )
+
+      .where(and(...conditions))
+      .orderBy(desc(zuvyMentorSlotBooking.bookedAt))
+      .limit(limit)
+      .offset(offset);
+
+    return data;
   }
 
   /* ==========================================================================

--- a/src/integrations/google/google.controller.ts
+++ b/src/integrations/google/google.controller.ts
@@ -63,8 +63,8 @@ export class GoogleController {
 
     let redirectUrl = result.redirectUrl;
 
-    if (!redirectUrl?.startsWith(process.env.FRONTEND_URL)) {
-      redirectUrl = `${process.env.FRONTEND_URL}/dashboard`;
+    if (!redirectUrl?.startsWith(process.env.ZUVY_BASH_URL)) {
+      redirectUrl = `${process.env.ZUVY_BASH_URL}/dashboard`;
     }
 
     return res.redirect(redirectUrl);

--- a/src/integrations/google/google.controller.ts
+++ b/src/integrations/google/google.controller.ts
@@ -24,20 +24,27 @@ export class GoogleController {
   */
   @Public()
   @Get('connect')
-  async connect(@Query('token') token: string, @Res() res) {
+  async connect(
+    @Query('token') token: string,
+    @Query('redirectUrl') redirectUrl: string,
+    @Res() res,
+  ) {
     if (!token) {
       throw new UnauthorizedException('Token not found');
     }
 
-    const payload: any = jwt.decode(token);
+    const payload: any = jwt.verify(token, process.env.JWT_SECRET_KEY);
 
-    if (!payload) {
+    if (!payload?.sub) {
       throw new UnauthorizedException('Invalid token');
     }
 
     const userId = payload.sub;
 
-    const url = await this.googleService.generateConnectUrl(userId);
+    const url = await this.googleService.generateConnectUrl(
+      userId,
+      redirectUrl,
+    );
 
     return res.redirect(url);
   }
@@ -47,8 +54,19 @@ export class GoogleController {
   */
   @Public()
   @Get('callback')
-  async callback(@Query('code') code: string, @Query('state') state: string) {
-    console.log('Google callback triggered', { code, state });
-    return this.googleService.handleCallback(code, state);
+  async googleCallback(
+    @Query('code') code: string,
+    @Query('state') state: string,
+    @Res() res,
+  ) {
+    const result = await this.googleService.handleCallback(code, state);
+
+    let redirectUrl = result.redirectUrl;
+
+    if (!redirectUrl?.startsWith(process.env.FRONTEND_URL)) {
+      redirectUrl = `${process.env.FRONTEND_URL}/dashboard`;
+    }
+
+    return res.redirect(redirectUrl);
   }
 }

--- a/src/integrations/google/google.service.ts
+++ b/src/integrations/google/google.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { google } from 'googleapis';
 import { db } from '../../db';
 import { sql } from 'drizzle-orm';
@@ -14,12 +14,17 @@ export class GoogleService {
   /*
   Generate Google OAuth URL
   */
-  async generateConnectUrl(userId: number) {
+  async generateConnectUrl(userId: number, redirectUrl?: string) {
+    const statePayload = {
+      userId,
+      redirectUrl: redirectUrl || null,
+    };
+
     const url = this.oauthClient.generateAuthUrl({
       access_type: 'offline',
       prompt: 'consent',
       scope: ['https://www.googleapis.com/auth/calendar'],
-      state: userId.toString(),
+      state: Buffer.from(JSON.stringify(statePayload)).toString('base64'),
     });
 
     return url;
@@ -29,19 +34,31 @@ export class GoogleService {
   Handle Google OAuth callback
   */
   async handleCallback(code: string, state: string) {
-    const userId = Number(state);
+    if (!state) {
+      throw new UnauthorizedException('Missing OAuth state');
+    }
+
+    const decoded = JSON.parse(Buffer.from(state, 'base64').toString('utf-8'));
+
+    if (!decoded?.userId) {
+      throw new UnauthorizedException('Invalid OAuth state');
+    }
+
+    const userId = Number(decoded.userId);
+    const redirectUrl = decoded.redirectUrl;
 
     const { tokens } = await this.oauthClient.getToken(code);
 
     await db.execute(sql`
-  UPDATE zuvy_mentor_slot_management
-  SET google_refresh_token =
-      COALESCE(${tokens.refresh_token}, google_refresh_token)
-  WHERE mentor_user_id = ${BigInt(userId)}
-`);
+    UPDATE zuvy_mentor_slot_management
+    SET google_refresh_token =
+        COALESCE(${tokens.refresh_token}, google_refresh_token)
+    WHERE mentor_user_id = ${BigInt(userId)}
+  `);
 
     return {
       message: 'Google Calendar connected successfully',
+      redirectUrl,
     };
   }
 }


### PR DESCRIPTION
feat(sessions, google): add session filters, pagination, slot timing and improve OAuth callback redirect

Session APIs improvements:
- Added backend filtering for mentor sessions (/mentor-sessions/mentor/my)
  - upcoming
  - completed
  - reschedule
  - all
- Added backend filtering for student sessions (/mentor-sessions/my)
  - upcoming
  - completed
  - cancelled
  - all
- Added pagination support (limit, offset) for both APIs
- Joined slot availability table to include session timing
  - slotStart
  - slotEnd
- Included mentor and student names in session responses
- Added sorting for sessions by booking time

Google Calendar integration improvements:
- Added redirectUrl support in Google OAuth state
- Implemented base64 encoded state payload for OAuth flow
- Updated callback handler to redirect user back to the originating frontend route after successful Google Calendar connection