### PR TITLE
add optional userId filter to overall-analysis endpoint

### DIFF
--- a/src/controller/adminAssessment/adminAssessment.controller.ts
+++ b/src/controller/adminAssessment/adminAssessment.controller.ts
@@ -452,19 +452,26 @@ export class AdminAssessmentController {
     }
   }
 
-  @Get('/overall-analysis/:bootcampId')
+  @Get('/overall-analysis')
   @ApiOperation({
     summary:
-      'Get overall analysis of all students in a bootcamp — attendance, assessment scores, mentor, college, degree, LinkedIn',
+      'Get overall analysis of all students in a batch — attendance, assessment scores, mentor, college, degree, LinkedIn',
   })
   @ApiBearerAuth('JWT-auth')
+  @ApiQuery({ name: 'batchId', required: true, type: Number })
+  @ApiQuery({ name: 'userId', required: false, type: Number })
   async getOverallAnalysis(
-    @Param('bootcampId', ParseIntPipe) bootcampId: number,
+    @Query('batchId') batchId: string,
+    @Query('userId') userId: string,
     @Res() res,
   ) {
     try {
-      const result =
-        await this.adminAssessmentService.getOverallAnalysis(bootcampId);
+      const parsedBatchId = parseInt(batchId, 10);
+      const parsedUserId = userId ? parseInt(userId, 10) : undefined;
+      const result = await this.adminAssessmentService.getOverallAnalysis(
+        parsedBatchId,
+        parsedUserId,
+      );
       if (result.statusCode === STATUS_CODES.NOT_FOUND) {
         return ErrorResponse.BadRequestException(result.message).send(res);
       }

--- a/src/controller/adminAssessment/adminAssessment.service.ts
+++ b/src/controller/adminAssessment/adminAssessment.service.ts
@@ -2226,9 +2226,28 @@ Team Zuvy`;
     }
   }
 
-  async getOverallAnalysis(bootcampId: number): Promise<any> {
+  async getOverallAnalysis(batchId: number, userId?: number): Promise<any> {
     try {
-      // 1. Fetch course name
+      // 1. Fetch bootcampId and course name from batchId
+      const batch = await db
+        .select({
+          bootcampId: zuvyBatches.bootcampId,
+          batchName: zuvyBatches.name,
+        })
+        .from(zuvyBatches)
+        .where(eq(zuvyBatches.id, batchId))
+        .limit(1);
+
+      if (!batch.length) {
+        return {
+          statusCode: STATUS_CODES.NOT_FOUND,
+          message: 'Batch not found',
+          data: [],
+        };
+      }
+
+      const bootcampId = batch[0].bootcampId;
+
       const course = await db
         .select({ name: zuvyBootcamps.name })
         .from(zuvyBootcamps)
@@ -2237,7 +2256,7 @@ Team Zuvy`;
 
       const courseName = course[0]?.name || null;
 
-      // 2. Fetch all enrolled students (in a batch) with user info, attendance and batch name
+      // 2. Fetch enrolled students for this batch with user info and attendance
       const enrollments = await db
         .select({
           userId: zuvyBatchEnrollments.userId,
@@ -2252,8 +2271,8 @@ Team Zuvy`;
         .leftJoin(zuvyBatches, eq(zuvyBatches.id, zuvyBatchEnrollments.batchId))
         .where(
           and(
-            eq(zuvyBatchEnrollments.bootcampId, bootcampId),
-            isNotNull(zuvyBatchEnrollments.batchId),
+            eq(zuvyBatchEnrollments.batchId, batchId),
+            userId ? eq(zuvyBatchEnrollments.userId, userId) : undefined,
           ),
         );
 


### PR DESCRIPTION
1. Add optional `userId` query param to GET /overall-analysis/:bootcampId
2. Admins can now filter overall analysis by a specific student within a batch.
3. When `userId` is provided, only that student's data is returned — including
4. attendance, assessment scores, mentor sessions, and profile info.
5. When omitted, all enrolled students' data is returned as before.
6. Supports individual student report view and download for admins.