### PR TITLE
add session invalidation for role and user permission updates

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -46,6 +46,7 @@ import { NotificationService } from './controller/notification/notification.serv
 import { GoogleModule } from './integrations/google/google.module';
 import { NewNotificationModule } from './controller/notification/notification.module';
 import { SuperAdminModule } from './super-admin/super-admin.module';
+import { PermissionsGuard } from './rbac/guards/permissions.guard';
 
 let { GOOGLE_CLIENT_ID, GOOGLE_SECRET, GOOGLE_REDIRECT_URI, JWT_SECRET_KEY } =
   process.env;
@@ -105,6 +106,10 @@ let { GOOGLE_CLIENT_ID, GOOGLE_SECRET, GOOGLE_REDIRECT_URI, JWT_SECRET_KEY } =
     {
       provide: APP_GUARD,
       useClass: OrgAuthorizationGuard,
+    },
+    {
+      provide: APP_GUARD,
+      useClass: PermissionsGuard,
     },
     JwtMiddleware,
     Reflector,

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -482,6 +482,27 @@ export class AuthService {
       }
 
       const payload = await this.jwtService.verifyAsync(token);
+      const sessionConditions = [
+        eq(zuvyUserOrganizations.userId, Number(payload.sub)),
+      ];
+
+      if (payload.orgId) {
+        sessionConditions.push(
+          eq(zuvyUserOrganizations.organizationId, Number(payload.orgId)),
+        );
+      } else {
+        sessionConditions.push(isNull(zuvyUserOrganizations.organizationId));
+      }
+
+      const [storedSession] = await db
+        .select({ accessToken: zuvyUserOrganizations.accessToken })
+        .from(zuvyUserOrganizations)
+        .where(and(...sessionConditions));
+
+      if (!storedSession || storedSession.accessToken !== token) {
+        throw new UnauthorizedException('Token has been invalidated');
+      }
+
       return payload;
     } catch (error) {
       throw new UnauthorizedException('Invalid token');

--- a/src/rbac/decorators/permissions.decorator.ts
+++ b/src/rbac/decorators/permissions.decorator.ts
@@ -1,0 +1,15 @@
+import { SetMetadata } from '@nestjs/common';
+import { ResourceList } from '../utility';
+
+export const RequirePermission = (resource: string, action: string) => {
+  const resourceKey = resource.toLowerCase();
+  const normalizedAction = action.toLowerCase() === 'view' ? 'read' : action;
+  const formattedPermission = ResourceList[resourceKey]?.[normalizedAction];
+
+  return SetMetadata('permissions', [
+    formattedPermission || `${resourceKey}:${action}`,
+  ]);
+};
+
+export const RequirePermissions = (...permissions: string[]) =>
+  SetMetadata('permissions', permissions);

--- a/src/rbac/dto/permission.dto.ts
+++ b/src/rbac/dto/permission.dto.ts
@@ -230,10 +230,21 @@ export class AssignPermissionsToRoleDto {
   @ApiProperty({
     description: 'Organization ID',
     example: 1,
+    required: false,
   })
   @IsNumber()
   @IsOptional()
   orgId?: number;
+
+  @ApiProperty({
+    description:
+      'Organization ID used for organization-scoped role permissions',
+    example: 1,
+    required: false,
+  })
+  @IsNumber()
+  @IsOptional()
+  organizationId?: number;
 
   @ApiProperty({
     description: 'Resource ID to assign the permissions to',

--- a/src/rbac/guards/permissions.guard.ts
+++ b/src/rbac/guards/permissions.guard.ts
@@ -6,6 +6,53 @@ import {
 } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { RbacPermissionService } from '../rbac.permission.service';
+import { IS_PUBLIC_KEY } from 'src/auth/decorators/public.decorator';
+import { ResourceList } from '../utility';
+
+const ROUTE_RESOURCE_ALIASES: Record<string, keyof typeof ResourceList> = {
+  admin: 'submission',
+  'ai-assessment': 'submission',
+  auditlog: 'rolesandpermission',
+  batch: 'batch',
+  batches: 'batch',
+  bootcamp: 'course',
+  classes: 'batch',
+  codingPlatform: 'codingquestion',
+  content: 'course',
+  instructor: 'course',
+  level: 'student',
+  org: 'organization',
+  permissions: 'rolesandpermission',
+  questions: 'question',
+  'questions-by-llm': 'question',
+  resources: 'rolesandpermission',
+  rbac: 'rolesandpermission',
+  roles: 'rolesandpermission',
+  student: 'student',
+  submission: 'submission',
+  'super-admin': 'organization',
+  tracking: 'course',
+  trackinglog: 'rolesandpermission',
+  users: 'user',
+};
+
+const WRITE_WORDS = [
+  'assign',
+  'approve',
+  'book',
+  'cancel',
+  'complete',
+  'create',
+  'edit',
+  'mark',
+  'merge',
+  'process',
+  'reassign',
+  'reschedule',
+  'submit',
+  'update',
+  'upload',
+];
 
 @Injectable()
 export class PermissionsGuard implements CanActivate {
@@ -15,18 +62,27 @@ export class PermissionsGuard implements CanActivate {
   ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
-    const requiredPermissions = this.reflector.get<string[]>(
-      'permissions',
-      context.getHandler(),
-    );
+    const request = context.switchToHttp().getRequest();
 
-    // If no permissions are required, allow access
-    if (!requiredPermissions || requiredPermissions.length === 0) {
+    if (request.originalUrl?.startsWith('/webhooks/zoom')) {
       return true;
     }
 
-    const request = context.switchToHttp().getRequest();
-    const user = request.user[0]; // Assuming user is an array as seen in controllers
+    const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+    if (isPublic) {
+      return true;
+    }
+
+    const requiredPermissions = this.getRequiredPermissions(context, request);
+
+    if (!requiredPermissions.length) {
+      return true;
+    }
+
+    const user = Array.isArray(request.user) ? request.user[0] : request.user;
 
     // Check if user exists and has an ID
     if (!user || !user.id) {
@@ -39,21 +95,32 @@ export class PermissionsGuard implements CanActivate {
     }
 
     const orgId = user.orgId;
-    if (!orgId) {
-      throw new ForbiddenException('Organization context missing');
-    }
 
     try {
       // Check if user has all required permissions
       const hasPermissions =
         await this.rbacPermissionService.userHasPermissions(
-          user.id,
+          Number(user.id),
           requiredPermissions,
-          orgId,
+          orgId ? Number(orgId) : null,
         );
 
       if (!hasPermissions) {
-        throw new ForbiddenException('Insufficient permissions');
+        throw new ForbiddenException(
+          'You do not have permission to perform this action',
+        );
+      }
+
+      const hasResourceAccess =
+        await this.rbacPermissionService.validateAssignedResourceAccess(
+          user,
+          this.extractResourceIds(request),
+        );
+
+      if (!hasResourceAccess) {
+        throw new ForbiddenException(
+          'You are not allowed to access this resource',
+        );
       }
 
       return true;
@@ -61,7 +128,99 @@ export class PermissionsGuard implements CanActivate {
       if (error instanceof ForbiddenException) {
         throw error;
       }
-      throw new ForbiddenException('Permission check failed');
+      throw new ForbiddenException(
+        'You do not have permission to perform this action',
+      );
     }
+  }
+
+  private getRequiredPermissions(
+    context: ExecutionContext,
+    request: any,
+  ): string[] {
+    const decoratedPermissions =
+      this.reflector.getAllAndOverride<string[]>('permissions', [
+        context.getHandler(),
+        context.getClass(),
+      ]) || [];
+
+    if (decoratedPermissions.length) {
+      return decoratedPermissions;
+    }
+
+    const resourceKey = this.inferResourceKey(request);
+    if (!resourceKey) return [];
+
+    const action = this.inferAction(request);
+    const permission =
+      ResourceList[resourceKey]?.[action] ||
+      (action === 'assign' ? ResourceList[resourceKey]?.edit : undefined);
+    return permission ? [permission] : [];
+  }
+
+  private inferResourceKey(request: any): keyof typeof ResourceList | null {
+    const path = String(request.route?.path || request.path || '')
+      .replace(/^\/+/, '')
+      .split('/')[0];
+    const basePath = String(request.baseUrl || '').replace(/^\/+/, '');
+    const controller = basePath || path;
+    return ROUTE_RESOURCE_ALIASES[controller] || null;
+  }
+
+  private inferAction(
+    request: any,
+  ): 'read' | 'create' | 'edit' | 'delete' | 'assign' {
+    const path = String(request.originalUrl || request.url || '').toLowerCase();
+    if (path.includes('assign') || path.includes('reassign')) return 'assign';
+    if (request.method === 'GET') return 'read';
+    if (request.method === 'DELETE') return 'delete';
+    if (request.method === 'PUT' || request.method === 'PATCH') return 'edit';
+    if (WRITE_WORDS.some((word) => path.includes(word))) return 'edit';
+    return 'create';
+  }
+
+  private extractResourceIds(request: any): {
+    orgId?: number | null;
+    bootcampId?: number;
+    batchId?: number;
+  } {
+    const source = {
+      ...(request.params || {}),
+      ...(request.query || {}),
+      ...(request.body || {}),
+    };
+
+    const controller = this.getControllerName(request);
+    const canUseGenericIdAsBootcampId = [
+      'bootcamp',
+      'classes',
+      'content',
+      'instructor',
+      'tracking',
+    ].includes(controller);
+
+    return {
+      orgId: this.toNumber(source.orgId ?? source.organizationId),
+      bootcampId: this.toNumber(
+        source.bootcampId ??
+          source.bootcamp_id ??
+          (canUseGenericIdAsBootcampId ? source.id : undefined) ??
+          source.bootcamp_id,
+      ),
+      batchId: this.toNumber(source.batchId ?? source.batch_id),
+    };
+  }
+
+  private getControllerName(request: any): string {
+    const path = String(request.route?.path || request.path || '')
+      .replace(/^\/+/, '')
+      .split('/')[0];
+    return String(request.baseUrl || '').replace(/^\/+/, '') || path;
+  }
+
+  private toNumber(value: any): number | undefined {
+    if (value === undefined || value === null || value === '') return undefined;
+    const numericValue = Number(value);
+    return Number.isNaN(numericValue) ? undefined : numericValue;
   }
 }

--- a/src/rbac/rbac.controller.ts
+++ b/src/rbac/rbac.controller.ts
@@ -211,6 +211,7 @@ export class RbacController {
   ): Promise<any> {
     try {
       const orgId =
+        assignPermissionsDto.organizationId ??
         assignPermissionsDto.orgId ??
         (req.user[0]?.orgId ? parseInt(req.user[0].orgId) : undefined);
       const result = await this.rbacPermissionService.assignPermissionsToRole(

--- a/src/rbac/rbac.permission.service.ts
+++ b/src/rbac/rbac.permission.service.ts
@@ -17,6 +17,7 @@ import {
 } from './dto/permission.dto';
 import {
   users,
+  blacklistedTokens,
   zuvyPermissions,
   zuvyResources,
   zuvyPermissionsRoles,
@@ -24,11 +25,18 @@ import {
   zuvyUserRoles,
   zuvyUserRolesAssigned,
   zuvyAuditLogs,
+  zuvyUserOrganizations,
+  zuvyBatches,
+  zuvyBootcamps,
 } from 'drizzle/schema';
+import { JwtService } from '@nestjs/jwt';
+import { ResourceList } from './utility';
 
 @Injectable()
 export class RbacPermissionService {
   private readonly logger = new Logger(RbacPermissionService.name);
+
+  constructor(private readonly jwtService: JwtService) {}
 
   async createPermission(
     createPermissionDto: CreatePermissionDto,
@@ -219,13 +227,14 @@ export class RbacPermissionService {
   async getUserPermissions(
     userId: number,
     orgId: number | null,
-  ): Promise<{ permission: string; resource: string }[]> {
+  ): Promise<{ permission: string; resource: string; resourceKey?: string }[]> {
     try {
       // Drizzle ORM equivalent for the above SQL
-      const result = await db
+      const rolePermissions = await db
         .selectDistinct({
           permission: zuvyPermissions.name,
           resource: zuvyResources.name,
+          resourceKey: zuvyResources.key,
         })
         .from(zuvyPermissions)
         .innerJoin(
@@ -246,7 +255,7 @@ export class RbacPermissionService {
         )
         .where(
           and(
-            eq(zuvyUserRolesAssigned.userId, userId),
+            eq(zuvyUserRolesAssigned.userId, BigInt(userId)),
             orgId !== null
               ? eq(zuvyUserRolesAssigned.organizationId, orgId)
               : isNull(zuvyUserRolesAssigned.organizationId),
@@ -256,7 +265,30 @@ export class RbacPermissionService {
           ),
         );
 
-      return result;
+      const directPermissions = await db
+        .selectDistinct({
+          permission: zuvyPermissions.name,
+          resource: zuvyResources.name,
+          resourceKey: zuvyResources.key,
+        })
+        .from(zuvyUserPermissions)
+        .innerJoin(
+          zuvyPermissions,
+          eq(zuvyUserPermissions.permissionId, zuvyPermissions.id),
+        )
+        .innerJoin(
+          zuvyResources,
+          eq(zuvyPermissions.resourcesId, zuvyResources.id),
+        )
+        .where(eq(zuvyUserPermissions.userId, BigInt(userId)));
+
+      const seen = new Set<string>();
+      return [...rolePermissions, ...directPermissions].filter((permission) => {
+        const key = `${permission.resourceKey}:${permission.permission}`;
+        if (seen.has(key)) return false;
+        seen.add(key);
+        return true;
+      });
     } catch (err) {
       this.logger.error(
         `Error getting user permissions for user ${userId}:`,
@@ -298,8 +330,29 @@ export class RbacPermissionService {
       }
 
       const userPermissions = await this.getUserPermissions(userId, orgId);
+      const permissionSet = new Set<string>();
+
+      userPermissions.forEach((userPermission) => {
+        permissionSet.add(userPermission.permission);
+        permissionSet.add(
+          `${userPermission.resourceKey}:${userPermission.permission}`,
+        );
+
+        const resourceKey = userPermission.resourceKey?.toLowerCase();
+        let action = userPermission.permission.toLowerCase();
+        if (action === 'view') action = 'read';
+
+        const formattedPermission =
+          resourceKey && ResourceList[resourceKey]
+            ? ResourceList[resourceKey][action]
+            : undefined;
+        if (formattedPermission) {
+          permissionSet.add(formattedPermission);
+        }
+      });
+
       const hasAllPermissions = requiredPermissions.every((requiredPerm) =>
-        userPermissions.some((up) => up.permission === requiredPerm),
+        permissionSet.has(requiredPerm),
       );
 
       return hasAllPermissions;
@@ -307,6 +360,151 @@ export class RbacPermissionService {
       this.logger.error(`Error checking permissions for user ${userId}:`, err);
       return false;
     }
+  }
+
+  private async invalidateStoredTokens(
+    sessions: { accessToken: string | null; refreshToken: string | null }[],
+    userId: number,
+  ) {
+    const tokens = sessions
+      .flatMap((session) => [session.accessToken, session.refreshToken])
+      .filter(Boolean) as string[];
+
+    for (const token of tokens) {
+      try {
+        const decoded = this.jwtService.decode(token) as { exp?: number };
+        const expiresAt = decoded?.exp
+          ? new Date(decoded.exp * 1000)
+          : new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+
+        await db
+          .insert(blacklistedTokens)
+          .values({
+            token,
+            userId: BigInt(userId),
+            expiresAt,
+          } as typeof blacklistedTokens.$inferInsert)
+          .onConflictDoNothing();
+      } catch (error: any) {
+        this.logger.warn(
+          `Failed to blacklist token for user ${userId}: ${error?.message ?? error}`,
+        );
+      }
+    }
+  }
+
+  private async invalidateSessionRows(userId: number, orgId?: number | null) {
+    const conditions = [eq(zuvyUserOrganizations.userId, userId)];
+    if (orgId !== undefined) {
+      conditions.push(
+        orgId === null
+          ? isNull(zuvyUserOrganizations.organizationId)
+          : eq(zuvyUserOrganizations.organizationId, orgId),
+      );
+    }
+
+    const sessions = await db
+      .select({
+        accessToken: zuvyUserOrganizations.accessToken,
+        refreshToken: zuvyUserOrganizations.refreshToken,
+      })
+      .from(zuvyUserOrganizations)
+      .where(and(...conditions));
+
+    if (sessions.length) {
+      await this.invalidateStoredTokens(sessions, userId);
+    }
+
+    await db
+      .update(zuvyUserOrganizations)
+      .set({ accessToken: null, refreshToken: null } as any)
+      .where(and(...conditions));
+  }
+
+  private async invalidateSpecificUserSession(userId: number) {
+    await this.invalidateSessionRows(userId);
+  }
+
+  private async invalidateSessionsForRoleUsers(roleId: number, orgId: number) {
+    const assignedUsers = await db
+      .selectDistinct({ userId: zuvyUserRolesAssigned.userId })
+      .from(zuvyUserRolesAssigned)
+      .where(
+        and(
+          eq(zuvyUserRolesAssigned.roleId, roleId),
+          eq(zuvyUserRolesAssigned.organizationId, orgId),
+        ),
+      );
+
+    for (const assignedUser of assignedUsers) {
+      await this.invalidateSessionRows(Number(assignedUser.userId), orgId);
+    }
+  }
+
+  async validateAssignedResourceAccess(
+    user: { id: number | string; roles?: string[]; orgId?: number | string },
+    resourceIds: {
+      orgId?: number | null;
+      bootcampId?: number;
+      batchId?: number;
+    },
+  ): Promise<boolean> {
+    const roles = user.roles || [];
+    if (
+      roles.includes('super_admin') ||
+      roles.includes('admin') ||
+      (!roles.includes('instructor') && !roles.includes('ops'))
+    ) {
+      return true;
+    }
+
+    const tokenOrgId = user.orgId ? Number(user.orgId) : null;
+    if (
+      resourceIds.orgId !== undefined &&
+      resourceIds.orgId !== null &&
+      tokenOrgId !== Number(resourceIds.orgId)
+    ) {
+      return false;
+    }
+
+    let bootcampId = resourceIds.bootcampId;
+    if (!bootcampId && resourceIds.batchId) {
+      const [batch] = await db
+        .select({ bootcampId: zuvyBatches.bootcampId })
+        .from(zuvyBatches)
+        .where(eq(zuvyBatches.id, resourceIds.batchId))
+        .limit(1);
+      bootcampId = batch?.bootcampId ? Number(batch.bootcampId) : undefined;
+    }
+
+    if (!bootcampId) return true;
+
+    const [bootcamp] = await db
+      .select({ organizationId: zuvyBootcamps.organizationId })
+      .from(zuvyBootcamps)
+      .where(eq(zuvyBootcamps.id, bootcampId))
+      .limit(1);
+
+    if (
+      bootcamp?.organizationId &&
+      tokenOrgId &&
+      Number(bootcamp.organizationId) !== tokenOrgId
+    ) {
+      return false;
+    }
+
+    const assignedBatches = await db
+      .select({ id: zuvyBatches.id })
+      .from(zuvyBatches)
+      .where(
+        and(
+          eq(zuvyBatches.bootcampId, bootcampId),
+          eq(zuvyBatches.instructorId, Number(user.id)),
+        ),
+      )
+      .limit(1);
+
+    return assignedBatches.length > 0;
   }
 
   async assignExtraPermissionToUser(
@@ -384,7 +582,7 @@ export class RbacPermissionService {
       const userExists = await db
         .select({ id: users.id })
         .from(users)
-        .where(eq(users.id, userId))
+        .where(eq(users.id, BigInt(userId)))
         .limit(1);
       if (!userExists.length) {
         throw new NotFoundException('User not found');
@@ -414,17 +612,23 @@ export class RbacPermissionService {
       }
 
       for (const permissionId of assignPermissionsDto.permissions) {
-        const exists = await db.query.zuvyUserPermissions.findFirst({
-          where: (u, { eq, and }) =>
+        const [exists] = await db
+          .select({ id: zuvyUserPermissions.id })
+          .from(zuvyUserPermissions)
+          .where(
             and(
-              eq(u.userId, BigInt(assignPermissionsDto.userId)),
-              eq(u.permissionId, permissionId),
+              eq(
+                zuvyUserPermissions.userId,
+                BigInt(assignPermissionsDto.userId),
+              ),
+              eq(zuvyUserPermissions.permissionId, permissionId),
             ),
-        });
+          )
+          .limit(1);
 
         if (!exists) {
           const insertData = {
-            userId: assignPermissionsDto.userId,
+            userId: BigInt(assignPermissionsDto.userId),
             permissionId,
           };
           insertUserPermission = await db
@@ -433,6 +637,8 @@ export class RbacPermissionService {
             .returning();
         }
       }
+      await this.invalidateSpecificUserSession(userId);
+
       return {
         status: 'success',
         code: 200,
@@ -451,8 +657,15 @@ export class RbacPermissionService {
   ) {
     try {
       const { resourceId, roleId, permissions } = dto;
+      if (
+        orgId === undefined ||
+        orgId === null ||
+        Number.isNaN(Number(orgId))
+      ) {
+        throw new BadRequestException('Organization context missing');
+      }
 
-      return await db.transaction(async (tx) => {
+      const response = await db.transaction(async (tx) => {
         const [resource] = await tx
           .select()
           .from(zuvyResources)
@@ -510,6 +723,7 @@ export class RbacPermissionService {
               and(
                 eq(zuvyPermissionsRoles.roleId, roleId),
                 inArray(zuvyPermissionsRoles.permissionId, disableIds),
+                eq(zuvyPermissionsRoles.orgId, orgId),
               ),
             );
         }
@@ -517,7 +731,12 @@ export class RbacPermissionService {
         const assigned = await tx
           .select({ permissionId: zuvyPermissionsRoles.permissionId })
           .from(zuvyPermissionsRoles)
-          .where(eq(zuvyPermissionsRoles.roleId, roleId));
+          .where(
+            and(
+              eq(zuvyPermissionsRoles.roleId, roleId),
+              eq(zuvyPermissionsRoles.orgId, orgId),
+            ),
+          );
 
         return {
           status: 'success',
@@ -529,6 +748,8 @@ export class RbacPermissionService {
           },
         };
       });
+      await this.invalidateSessionsForRoleUsers(roleId, orgId);
+      return response;
     } catch (error) {
       this.logger.error('Error in assignPermissionsToRole:', error);
       if (error instanceof HttpException) throw error;


### PR DESCRIPTION
Feature:
1. Invalidate user sessions on role and permission changes

- Invalidate all users of a role when role permissions are updated
- Invalidate specific user sessions on user permission update
- Ensure RBAC endpoints trigger session invalidation

2. Enforce global permission checks and resource-level authorization

- Introduced middleware for permission validation across all endpoints
- Added orgId and role-based access checks in services
- Prevented unauthorized and cross-org access (403 responses)
- Enabled session invalidation on RBAC updates