### PR TITLE
QA fixes alongside permissionsguard added

### DIFF
--- a/src/controller/mentor-slot/MENTOR_SLOT_ROUTE_MIGRATION.md
+++ b/src/controller/mentor-slot/MENTOR_SLOT_ROUTE_MIGRATION.md
@@ -1,0 +1,67 @@
+# Mentor Slot API Route Migration
+
+This document maps the old mentor-slot APIs to the new role-separated APIs.
+
+Old APIs are still present for backward compatibility. Frontend can migrate by replacing the route path with the matching new route below.
+
+## Student Routes
+
+| Feature                       | Old Route                                                 | New Route                                                                  | Definition Change                                                                                                                                                                         |
+| ----------------------------- | --------------------------------------------------------- | -------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| List/search mentors           | `GET /mentors`                                            | `GET /student/mentors`                                                     | No request definition change. Same query DTO: `limit`, `offset`, `role`, `expertise`, `title`, `search`. New route is JWT-protected because it is inside the student controller.          |
+| Get mentor profile            | `GET /mentors/:mentorUserId`                              | `GET /student/mentors/:mentorUserId`                                       | No parameter definition change. New route is JWT-protected.                                                                                                                               |
+| Get mentor availability       | `GET /mentors/:mentorId/availability`                     | `GET /student/mentors/:mentorId/availability`                              | No parameter definition change. New route is JWT-protected.                                                                                                                               |
+| Book mentor slot              | `POST /mentor-slots/book`                                 | `POST /student/mentor-slots/book`                                          | No body change. Uses `BookSlotDto` with `slotId`.                                                                                                                                         |
+| Student bookings              | `GET /mentor-slots/student/my`                            | `GET /student/mentor-slots/my`                                             | No request definition change.                                                                                                                                                             |
+| Student booking metrics       | `GET /mentor-slots/student/metrics`                       | `GET /student/mentor-slots/metrics`                                        | No request definition change.                                                                                                                                                             |
+| Request reschedule            | `POST /mentor-slots/:bookingId/reschedule?slotId=:slotId` | `POST /student/mentor-slots/bookings/:bookingId/reschedule?slotId=:slotId` | No body/query definition change. Uses `ProposeRescheduleDto` body with `reason`; `slotId` remains query param. New service check requires the booking to belong to the logged-in student. |
+| Cancel booking as student     | `POST /mentor-slots/:bookingId/cancel`                    | `POST /student/mentor-slots/bookings/:bookingId/cancel`                    | No body change. Uses `CancelBookingDto` with `reason`, `cancelledBy`. New service check requires logged-in user to own the booking and match `cancelledBy`.                               |
+| Booking recordings as student | `GET /mentor-slots/:bookingId/recordings`                 | `GET /student/mentor-slots/bookings/:bookingId/recordings`                 | No parameter definition change.                                                                                                                                                           |
+| Student session list          | `GET /mentor-sessions/my`                                 | `GET /student/mentor-sessions/my`                                          | No query definition change. Optional query params: `filter`, `limit`, `offset`.                                                                                                           |
+| Student session detail        | `GET /mentor-sessions/:sessionId`                         | `GET /student/mentor-sessions/:sessionId`                                  | No parameter definition change.                                                                                                                                                           |
+
+## Instructor Routes
+
+| Feature                          | Old Route                                          | New Route                                                              | Definition Change                                                                                                                                           |
+| -------------------------------- | -------------------------------------------------- | ---------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Create mentor slot               | `POST /mentor-slots/create`                        | `POST /instructor/mentor-slots/create`                                 | No body change. Uses `CreateSlotDto`.                                                                                                                       |
+| Delete mentor slot               | `DELETE /mentor-slots/:slotId`                     | `DELETE /instructor/mentor-slots/:slotId`                              | No parameter definition change.                                                                                                                             |
+| Instructor weekly slots          | `GET /mentor-slots/my`                             | `GET /instructor/mentor-slots/my`                                      | No query definition change. `sort` remains optional and supports `asc`, `desc`. `weekOffset` remains optional.                                              |
+| Slot details                     | `GET /mentor-slots/:slotId/details`                | `GET /instructor/mentor-slots/:slotId/details`                         | No parameter definition change. This is instructor-owned only in service behavior.                                                                          |
+| Accept reschedule                | `POST /mentor-slots/:bookingId/reschedule/accept`  | `POST /instructor/mentor-slots/bookings/:bookingId/reschedule/accept`  | No body change. New service check requires the booking to belong to the logged-in instructor.                                                               |
+| Decline reschedule               | `POST /mentor-slots/:bookingId/reschedule/decline` | `POST /instructor/mentor-slots/bookings/:bookingId/reschedule/decline` | No body change. New service check requires the booking to belong to the logged-in instructor.                                                               |
+| Submit mentor feedback           | `POST /mentor-slots/:bookingId/feedback`           | `POST /instructor/mentor-slots/bookings/:bookingId/feedback`           | No body change. Uses `FeedbackDto`. New service check requires the booking to belong to the logged-in instructor.                                           |
+| Mark attendance                  | `POST /mentor-slots/:bookingId/attendance`         | `POST /instructor/mentor-slots/bookings/:bookingId/attendance`         | No body change. Uses `AttendanceDto`. New service check requires the booking to belong to the logged-in instructor.                                         |
+| Complete session                 | `POST /mentor-slots/:bookingId/complete`           | `POST /instructor/mentor-slots/bookings/:bookingId/complete`           | No body change. New service check requires the booking to belong to the logged-in instructor.                                                               |
+| Cancel booking as instructor     | `POST /mentor-slots/:bookingId/cancel`             | `POST /instructor/mentor-slots/bookings/:bookingId/cancel`             | No body change. Uses `CancelBookingDto` with `reason`, `cancelledBy`. New service check requires logged-in user to own the booking and match `cancelledBy`. |
+| Booking recordings as instructor | `GET /mentor-slots/:bookingId/recordings`          | `GET /instructor/mentor-slots/bookings/:bookingId/recordings`          | No parameter definition change.                                                                                                                             |
+| Update mentor profile            | `PATCH /mentor-slots/mentor/profile`               | `PATCH /instructor/mentor-slots/profile`                               | No body change. Uses `UpdateMentorProfileDto`.                                                                                                              |
+| Get own mentor profile           | `GET /mentor-slots/mentor/profile`                 | `GET /instructor/mentor-slots/profile`                                 | No request definition change.                                                                                                                               |
+| Create/update mentor profile     | `POST /mentor-slots/mentor/profile`                | `POST /instructor/mentor-slots/profile`                                | No body change. Uses `UpdateMentorProfileDto`.                                                                                                              |
+| Mentor metrics                   | `GET /mentor-slots/metrics/me`                     | `GET /instructor/mentor-slots/metrics`                                 | No request definition change.                                                                                                                               |
+| Generate recurring slots         | `POST /mentor-slots/recurrence`                    | `POST /instructor/mentor-slots/recurrence`                             | No body change. Uses `RecurrenceDto`. New service check requires the `mentorSlotManagementId` to belong to the logged-in instructor.                        |
+| Instructor session list          | `GET /mentor-sessions/mentor/my`                   | `GET /instructor/mentor-sessions/my`                                   | No query definition change. Optional query params: `filter`, `sort`, `limit`, `offset`.                                                                     |
+| Instructor session detail        | `GET /mentor-sessions/:sessionId`                  | `GET /instructor/mentor-sessions/:sessionId`                           | No parameter definition change.                                                                                                                             |
+
+## APIs With New Authorization Behavior
+
+The request definitions are unchanged, but these APIs now enforce ownership using the logged-in JWT user:
+
+| API Area                             | New Behavior                                                                                                   |
+| ------------------------------------ | -------------------------------------------------------------------------------------------------------------- |
+| Student reschedule request           | Only the student who owns the booking can request reschedule.                                                  |
+| Instructor accept/decline reschedule | Only the instructor who owns the booking can accept or decline.                                                |
+| Instructor feedback                  | Only the instructor who owns the booking can submit feedback.                                                  |
+| Instructor attendance                | Only the instructor who owns the booking can mark attendance.                                                  |
+| Instructor complete session          | Only the instructor who owns the booking can complete it.                                                      |
+| Recurring slots                      | Instructor can generate recurrence only for their own mentor profile.                                          |
+| Cancel booking                       | Logged-in user must be either the booking student or mentor, and must match the submitted `cancelledBy` value. |
+
+## Notes For Frontend Migration
+
+- Prefer the new role-separated routes for all new frontend work.
+- Existing old routes remain available for now, but should be treated as legacy aliases.
+- Student-facing routes are under `/student`.
+- Instructor-facing routes are under `/instructor`.
+- Public mentor discovery is now also available under `/student/mentors`, but the original `/mentors` routes still exist.
+- The biggest path shape change is that booking-specific actions now include `/bookings/:bookingId/...` in the new role routes.

--- a/src/controller/mentor-slot/dto/create-slot.dto.ts
+++ b/src/controller/mentor-slot/dto/create-slot.dto.ts
@@ -1,16 +1,31 @@
-import { IsString, IsOptional, IsNumber } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsString,
+  IsOptional,
+  IsNumber,
+  IsDateString,
+  Min,
+} from 'class-validator';
 
 export class CreateSlotDto {
-  @IsString()
+  @ApiProperty({
+    description: 'Slot start time in ISO format with timezone',
+    example: '2026-05-10T10:00:00+05:30',
+  })
+  @IsDateString()
   slotStartDateTime: string;
 
-  @IsString()
+  @ApiProperty({
+    description: 'Slot end time in ISO format with timezone',
+    example: '2026-05-10T10:30:00+05:30',
+  })
+  @IsDateString()
   slotEndDateTime: string;
 
-  @IsOptional()
-  @IsNumber()
-  maxCapacity?: number;
-
+  @ApiPropertyOptional({
+    description: 'Optional topic for the mentoring session',
+    example: 'React Performance Optimization',
+  })
   @IsOptional()
   @IsString()
   topic?: string;

--- a/src/controller/mentor-slot/instructor-mentor-slot.controller.ts
+++ b/src/controller/mentor-slot/instructor-mentor-slot.controller.ts
@@ -28,10 +28,11 @@ import { CreateSlotDto } from './dto/create-slot.dto';
 import { AttendanceDto } from './dto/attendance.dto';
 import { UpdateMentorProfileDto } from './dto/update-mentor-profile.dto';
 import { RecurrenceDto } from './recurrence/dto/recurrence.dto';
+import { PermissionsGuard } from 'src/rbac/guards/permissions.guard';
 
 @ApiTags('Instructor Mentor APIs')
 @ApiBearerAuth('JWT-auth')
-@UseGuards(JwtAuthGuard)
+@UseGuards(JwtAuthGuard, PermissionsGuard)
 @Controller('instructor')
 export class InstructorMentorSlotController {
   constructor(

--- a/src/controller/mentor-slot/instructor-mentor-slot.controller.ts
+++ b/src/controller/mentor-slot/instructor-mentor-slot.controller.ts
@@ -1,0 +1,280 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Post,
+  Query,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiQuery,
+  ApiTags,
+} from '@nestjs/swagger';
+import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
+import { MentorSlotService } from './mentor-slot.service';
+import { SessionService } from './session/session.service';
+import { MentorMetricsService } from './metrics/mentor-metrics.service';
+import { MentorRecurrenceService } from './recurrence/mentor-recurrence.service';
+import { CancelBookingDto } from './dto/cancel-booking.dto';
+import { FeedbackDto } from './dto/feedback.dto';
+import { CreateSlotDto } from './dto/create-slot.dto';
+import { AttendanceDto } from './dto/attendance.dto';
+import { UpdateMentorProfileDto } from './dto/update-mentor-profile.dto';
+import { RecurrenceDto } from './recurrence/dto/recurrence.dto';
+
+@ApiTags('Instructor Mentor APIs')
+@ApiBearerAuth('JWT-auth')
+@UseGuards(JwtAuthGuard)
+@Controller('instructor')
+export class InstructorMentorSlotController {
+  constructor(
+    private readonly mentorSlotService: MentorSlotService,
+    private readonly sessionService: SessionService,
+    private readonly metricsService: MentorMetricsService,
+    private readonly recurrenceService: MentorRecurrenceService,
+  ) {}
+
+  @Post('mentor-slots/create')
+  @ApiOperation({ summary: 'Create a mentor availability slot as instructor' })
+  async createSlot(@Req() req, @Body() dto: CreateSlotDto) {
+    return this.mentorSlotService.createSlot(Number(req.user[0].id), dto);
+  }
+
+  @Delete('mentor-slots/:slotId')
+  @ApiOperation({ summary: 'Delete an instructor-owned mentor slot' })
+  async removeSlot(@Req() req, @Param('slotId', ParseIntPipe) slotId: number) {
+    return this.mentorSlotService.removeSlot(Number(req.user[0].id), slotId);
+  }
+
+  @Get('mentor-slots/my')
+  @ApiOperation({ summary: 'Get weekly mentor slots for the instructor' })
+  @ApiQuery({
+    name: 'sort',
+    required: false,
+    enum: ['asc', 'desc'],
+  })
+  async getMySlots(
+    @Req() req,
+    @Query('weekOffset') weekOffset = 0,
+    @Query('sort') sort: 'asc' | 'desc' = 'desc',
+  ) {
+    return this.mentorSlotService.getMySlots(
+      Number(req.user[0].id),
+      Number(weekOffset),
+      sort,
+    );
+  }
+
+  @Get('mentor-slots/:slotId/details')
+  @ApiOperation({ summary: 'Get instructor-owned slot details and bookings' })
+  async getSlotDetails(
+    @Req() req,
+    @Param('slotId', ParseIntPipe) slotId: number,
+  ) {
+    return this.mentorSlotService.getSlotDetails(
+      Number(req.user[0].id),
+      slotId,
+    );
+  }
+
+  @Post('mentor-slots/bookings/:bookingId/reschedule/accept')
+  @ApiOperation({
+    summary: 'Accept a pending booking reschedule as instructor',
+  })
+  async acceptReschedule(
+    @Req() req,
+    @Param('bookingId', ParseIntPipe) bookingId: number,
+  ) {
+    return this.mentorSlotService.acceptReschedule(
+      bookingId,
+      Number(req.user[0].id),
+    );
+  }
+
+  @Post('mentor-slots/bookings/:bookingId/reschedule/decline')
+  @ApiOperation({
+    summary: 'Decline a pending booking reschedule as instructor',
+  })
+  async declineReschedule(
+    @Req() req,
+    @Param('bookingId', ParseIntPipe) bookingId: number,
+  ) {
+    return this.mentorSlotService.declineReschedule(
+      bookingId,
+      Number(req.user[0].id),
+    );
+  }
+
+  @Post('mentor-slots/bookings/:bookingId/feedback')
+  @ApiOperation({ summary: 'Submit mentor feedback for an instructor session' })
+  async submitMentorFeedback(
+    @Req() req,
+    @Param('bookingId', ParseIntPipe) bookingId: number,
+    @Body() dto: FeedbackDto,
+  ) {
+    return this.mentorSlotService.submitMentorFeedback(
+      bookingId,
+      dto.feedback,
+      dto.rating,
+      Number(req.user[0].id),
+    );
+  }
+
+  @Post('mentor-slots/bookings/:bookingId/attendance')
+  @ApiOperation({ summary: 'Mark attendance for an instructor session' })
+  async markAttendance(
+    @Req() req,
+    @Param('bookingId', ParseIntPipe) bookingId: number,
+    @Body() dto: AttendanceDto,
+  ) {
+    return this.mentorSlotService.markAttendance(
+      bookingId,
+      dto.joinedAt,
+      dto.leftAt,
+      Number(req.user[0].id),
+    );
+  }
+
+  @Post('mentor-slots/bookings/:bookingId/complete')
+  @ApiOperation({ summary: 'Mark an instructor mentor session as completed' })
+  async completeSession(
+    @Req() req,
+    @Param('bookingId', ParseIntPipe) bookingId: number,
+  ) {
+    return this.mentorSlotService.completeSession(
+      bookingId,
+      Number(req.user[0].id),
+    );
+  }
+
+  @Post('mentor-slots/bookings/:bookingId/cancel')
+  @ApiOperation({ summary: 'Cancel an instructor mentor booking' })
+  async cancelBooking(
+    @Req() req,
+    @Param('bookingId', ParseIntPipe) bookingId: number,
+    @Body() dto: CancelBookingDto,
+  ) {
+    return this.mentorSlotService.cancelBooking(
+      bookingId,
+      dto.reason,
+      dto.cancelledBy,
+      Number(req.user[0].id),
+    );
+  }
+
+  @Get('mentor-slots/bookings/:bookingId/recordings')
+  @ApiOperation({ summary: 'Get recordings for an instructor mentor booking' })
+  async getBookingRecordings(
+    @Req() req,
+    @Param('bookingId', ParseIntPipe) bookingId: number,
+  ) {
+    return this.mentorSlotService.getBookingRecordings(
+      Number(req.user[0].id),
+      bookingId,
+    );
+  }
+
+  @Patch('mentor-slots/profile')
+  @ApiOperation({ summary: 'Update the instructor mentor profile' })
+  async updateProfile(@Req() req, @Body() dto: UpdateMentorProfileDto) {
+    return this.mentorSlotService.updateMentorProfile(
+      Number(req.user[0].id),
+      dto,
+    );
+  }
+
+  @Get('mentor-slots/profile')
+  @ApiOperation({ summary: 'Get the instructor mentor profile' })
+  async getMyProfile(@Req() req) {
+    return this.mentorSlotService.getMyMentorProfile(Number(req.user[0].id));
+  }
+
+  @Post('mentor-slots/profile')
+  @ApiOperation({ summary: 'Create or update the instructor mentor profile' })
+  async createOrUpdateProfile(@Req() req, @Body() dto: UpdateMentorProfileDto) {
+    return this.mentorSlotService.createOrUpdateMentorProfile(
+      Number(req.user[0].id),
+      dto,
+    );
+  }
+
+  @Get('mentor-slots/metrics')
+  @ApiOperation({ summary: 'Get mentor metrics for the instructor' })
+  async getMyMetrics(@Req() req) {
+    return this.metricsService.getMentorMetrics(BigInt(req.user[0].id));
+  }
+
+  @Post('mentor-slots/recurrence')
+  @ApiOperation({ summary: 'Generate recurring mentor slots as instructor' })
+  async generateRecurringSlots(@Req() req, @Body() dto: RecurrenceDto) {
+    return this.recurrenceService.generateRecurringSlots(
+      {
+        mentorSlotManagementId: dto.mentorSlotManagementId,
+        slotStart: new Date(dto.slotStart),
+        slotEnd: new Date(dto.slotEnd),
+        recurrenceRule: dto.recurrenceRule,
+        recurrenceEndDate: new Date(dto.recurrenceEndDate),
+        previewOnly: dto.previewOnly,
+      },
+      Number(req.user[0].id),
+    );
+  }
+
+  @Get('mentor-sessions/my')
+  @ApiOperation({ summary: 'Get mentor sessions hosted by the instructor' })
+  @ApiQuery({
+    name: 'filter',
+    required: false,
+    enum: ['all', 'upcoming', 'reschedule', 'completed'],
+  })
+  @ApiQuery({
+    name: 'sort',
+    required: false,
+    enum: ['asc', 'desc'],
+  })
+  @ApiQuery({
+    name: 'limit',
+    required: false,
+    type: Number,
+  })
+  @ApiQuery({
+    name: 'offset',
+    required: false,
+    type: Number,
+  })
+  async getMentorSessions(
+    @Req() req,
+    @Query('filter') filter?: string,
+    @Query('limit') limit = 10,
+    @Query('offset') offset = 0,
+    @Query('sort') sort: 'asc' | 'desc' = 'desc',
+  ) {
+    return this.sessionService.getMentorSessions(
+      BigInt(req.user[0].id),
+      req.user[0].orgId,
+      filter,
+      Number(limit),
+      Number(offset),
+      sort,
+    );
+  }
+
+  @Get('mentor-sessions/:sessionId')
+  @ApiOperation({ summary: 'Get details for an instructor mentor session' })
+  async getSessionDetail(
+    @Req() req,
+    @Param('sessionId', ParseIntPipe) sessionId: number,
+  ) {
+    return this.sessionService.getSessionDetail(
+      sessionId,
+      BigInt(req.user[0].id),
+    );
+  }
+}

--- a/src/controller/mentor-slot/mentor-slot.controller.ts
+++ b/src/controller/mentor-slot/mentor-slot.controller.ts
@@ -77,6 +77,7 @@ export class MentorSlotController {
       bookingId,
       dto.reason,
       dto.cancelledBy,
+      Number(req.user[0].id),
     );
   }
 
@@ -94,6 +95,7 @@ export class MentorSlotController {
     permissionName: 'editMentorDashboard',
   })
   async proposeReschedule(
+    @Req() req,
     @Param('bookingId', ParseIntPipe) bookingId: number,
     @Query('slotId') slotId: number,
     @Body() body: ProposeRescheduleDto,
@@ -102,6 +104,7 @@ export class MentorSlotController {
       bookingId,
       slotId,
       body.reason,
+      Number(req.user[0].id),
     );
   }
 
@@ -117,8 +120,14 @@ export class MentorSlotController {
     displayType: 'mentor booking reschedule',
     permissionName: 'editMentorDashboard',
   })
-  async acceptReschedule(@Param('bookingId', ParseIntPipe) bookingId: number) {
-    return this.mentorSlotService.acceptReschedule(bookingId);
+  async acceptReschedule(
+    @Req() req,
+    @Param('bookingId', ParseIntPipe) bookingId: number,
+  ) {
+    return this.mentorSlotService.acceptReschedule(
+      bookingId,
+      Number(req.user[0].id),
+    );
   }
 
   /* ==========================================================================
@@ -133,8 +142,14 @@ export class MentorSlotController {
     displayType: 'mentor booking reschedule',
     permissionName: 'editMentorDashboard',
   })
-  async declineReschedule(@Param('bookingId', ParseIntPipe) bookingId: number) {
-    return this.mentorSlotService.declineReschedule(bookingId);
+  async declineReschedule(
+    @Req() req,
+    @Param('bookingId', ParseIntPipe) bookingId: number,
+  ) {
+    return this.mentorSlotService.declineReschedule(
+      bookingId,
+      Number(req.user[0].id),
+    );
   }
 
   /* ==========================================================================
@@ -150,6 +165,7 @@ export class MentorSlotController {
     permissionName: 'editMentorDashboard',
   })
   async submitMentorFeedback(
+    @Req() req,
     @Param('bookingId', ParseIntPipe) bookingId: number,
     @Body() dto: FeedbackDto,
   ) {
@@ -157,6 +173,7 @@ export class MentorSlotController {
       bookingId,
       dto.feedback,
       dto.rating,
+      Number(req.user[0].id),
     );
   }
 
@@ -263,6 +280,7 @@ export class MentorSlotController {
     permissionName: 'editMentorDashboard',
   })
   async markAttendance(
+    @Req() req,
     @Param('bookingId', ParseIntPipe) bookingId: number,
     @Body() dto: AttendanceDto,
   ) {
@@ -270,6 +288,7 @@ export class MentorSlotController {
       bookingId,
       dto.joinedAt,
       dto.leftAt,
+      Number(req.user[0].id),
     );
   }
 
@@ -284,8 +303,14 @@ export class MentorSlotController {
     displayType: 'mentor session',
     permissionName: 'editMentorDashboard',
   })
-  async completeSession(@Param('bookingId', ParseIntPipe) bookingId: number) {
-    return this.mentorSlotService.completeSession(bookingId);
+  async completeSession(
+    @Req() req,
+    @Param('bookingId', ParseIntPipe) bookingId: number,
+  ) {
+    return this.mentorSlotService.completeSession(
+      bookingId,
+      Number(req.user[0].id),
+    );
   }
 
   /* ==========================================================================  

--- a/src/controller/mentor-slot/mentor-slot.module.ts
+++ b/src/controller/mentor-slot/mentor-slot.module.ts
@@ -10,6 +10,8 @@ import { SessionController } from './session/session.controller';
 import { SessionService } from './session/session.service';
 import { MentorPublicController } from './public/mentor-public.controller';
 import { MentorPublicService } from './public/mentor-public.service';
+import { StudentMentorSlotController } from './student-mentor-slot.controller';
+import { InstructorMentorSlotController } from './instructor-mentor-slot.controller';
 import { GoogleModule } from 'src/integrations/google/google.module';
 import { NewNotificationModule } from '../notification/notification.module';
 import { ZoomModule } from 'src/services/zoom/zoom.module';
@@ -30,6 +32,8 @@ import { TrackinglogModule } from 'src/trackinglog/trackinglog.module';
     MentorMetricsController,
     MentorPublicController,
     SessionController,
+    StudentMentorSlotController,
+    InstructorMentorSlotController,
   ],
   providers: [
     MentorSlotService,

--- a/src/controller/mentor-slot/mentor-slot.module.ts
+++ b/src/controller/mentor-slot/mentor-slot.module.ts
@@ -17,6 +17,7 @@ import { NewNotificationModule } from '../notification/notification.module';
 import { ZoomModule } from 'src/services/zoom/zoom.module';
 import { NotificationModule } from 'src/notification/notification.module';
 import { TrackinglogModule } from 'src/trackinglog/trackinglog.module';
+import { RbacModule } from '../../rbac/rbac.module';
 
 @Module({
   imports: [
@@ -25,6 +26,7 @@ import { TrackinglogModule } from 'src/trackinglog/trackinglog.module';
     ZoomModule,
     NotificationModule,
     TrackinglogModule,
+    RbacModule,
   ],
   controllers: [
     MentorSlotController,

--- a/src/controller/mentor-slot/mentor-slot.service.ts
+++ b/src/controller/mentor-slot/mentor-slot.service.ts
@@ -149,6 +149,48 @@ export class MentorSlotService {
     return true;
   }
 
+  private async ensureMentorOwnsBooking(userId: number, bookingId: number) {
+    await this.ensureUserIsMentor(userId);
+
+    const [booking] = await db
+      .select()
+      .from(zuvyMentorSlotBooking)
+      .where(eq(zuvyMentorSlotBooking.id, bookingId))
+      .limit(1);
+
+    if (!booking) {
+      throw new NotFoundException('Booking not found.');
+    }
+
+    if (booking.mentorUserId !== BigInt(userId)) {
+      throw new ForbiddenException('You do not own this booking.');
+    }
+
+    return booking;
+  }
+
+  private async ensureUserOwnsBooking(userId: number, bookingId: number) {
+    const [booking] = await db
+      .select()
+      .from(zuvyMentorSlotBooking)
+      .where(eq(zuvyMentorSlotBooking.id, bookingId))
+      .limit(1);
+
+    if (!booking) {
+      throw new NotFoundException('Booking not found.');
+    }
+
+    const userIdBigInt = BigInt(userId);
+    if (
+      booking.mentorUserId !== userIdBigInt &&
+      booking.studentUserId !== userIdBigInt
+    ) {
+      throw new ForbiddenException('You do not own this booking.');
+    }
+
+    return booking;
+  }
+
   private async ensureMentorZoomVerified(userId: number) {
     const mentorProfile = await this.getOrCreateMentorProfile(userId);
     console.log(
@@ -849,11 +891,28 @@ export class MentorSlotService {
     bookingId: number,
     reason: string,
     cancelledBy: 'mentor' | 'student',
+    actorUserId?: number,
   ) {
     if (!reason || reason.length < 10) {
       throw new BadRequestException(
         'Cancellation reason must be at least 10 characters.',
       );
+    }
+
+    if (actorUserId) {
+      const booking = await this.ensureUserOwnsBooking(actorUserId, bookingId);
+      const actorUserIdBigInt = BigInt(actorUserId);
+
+      if (
+        (cancelledBy === 'mentor' &&
+          booking.mentorUserId !== actorUserIdBigInt) ||
+        (cancelledBy === 'student' &&
+          booking.studentUserId !== actorUserIdBigInt)
+      ) {
+        throw new ForbiddenException(
+          `Only the ${cancelledBy} can cancel as ${cancelledBy}.`,
+        );
+      }
     }
 
     return db.transaction(async (trx) => {
@@ -1012,6 +1071,7 @@ export class MentorSlotService {
     bookingId: number,
     newSlotId: number,
     reason: string,
+    studentUserId?: number,
   ) {
     if (!reason || reason.length < 10) {
       throw new BadRequestException(
@@ -1031,6 +1091,10 @@ export class MentorSlotService {
 
     if (!booking) {
       throw new NotFoundException('Booking not found.');
+    }
+
+    if (studentUserId && booking.studentUserId !== BigInt(studentUserId)) {
+      throw new ForbiddenException('You do not own this booking.');
     }
 
     if (booking.status === 'cancelled') {
@@ -1133,7 +1197,12 @@ export class MentorSlotService {
     bookingId: number,
     feedback: any,
     rating?: number,
+    mentorUserId?: number,
   ) {
+    if (mentorUserId) {
+      await this.ensureMentorOwnsBooking(mentorUserId, bookingId);
+    }
+
     const [booking] = await db
       .select()
       .from(zuvyMentorSlotBooking)
@@ -1206,7 +1275,11 @@ export class MentorSlotService {
       .where(eq(zuvyMentorSlotAvailability.id, slotId));
   }
 
-  async acceptReschedule(bookingId: number) {
+  async acceptReschedule(bookingId: number, mentorUserId?: number) {
+    if (mentorUserId) {
+      await this.ensureMentorOwnsBooking(mentorUserId, bookingId);
+    }
+
     return db.transaction(async (trx) => {
       const [booking] = await trx
         .select()
@@ -1311,7 +1384,11 @@ export class MentorSlotService {
     });
   }
 
-  async declineReschedule(bookingId: number) {
+  async declineReschedule(bookingId: number, mentorUserId?: number) {
+    if (mentorUserId) {
+      await this.ensureMentorOwnsBooking(mentorUserId, bookingId);
+    }
+
     const [booking] = await db
       .select()
       .from(zuvyMentorSlotBooking)
@@ -1643,7 +1720,12 @@ export class MentorSlotService {
     bookingId: number,
     joinedAtStr: string,
     leftAtStr: string,
+    mentorUserId?: number,
   ) {
+    if (mentorUserId) {
+      await this.ensureMentorOwnsBooking(mentorUserId, bookingId);
+    }
+
     const joinedAt = new Date(joinedAtStr);
     const leftAt = new Date(leftAtStr);
 
@@ -1665,7 +1747,11 @@ export class MentorSlotService {
       .where(eq(zuvyMentorSlotBooking.id, bookingId));
   }
 
-  async completeSession(bookingId: number) {
+  async completeSession(bookingId: number, mentorUserId?: number) {
+    if (mentorUserId) {
+      await this.ensureMentorOwnsBooking(mentorUserId, bookingId);
+    }
+
     return db
       .update(zuvyMentorSlotBooking)
       .set({

--- a/src/controller/mentor-slot/mentor-slot.service.ts
+++ b/src/controller/mentor-slot/mentor-slot.service.ts
@@ -483,6 +483,7 @@ export class MentorSlotService {
         throw new BadRequestException('Slot is full.');
       }
 
+      // 12-hour booking notice is temporarily disabled for short-notice sessions.
       // this.enforceMinimumNotice(new Date(slot.slotStartDateTime));
 
       /* ========================================
@@ -1135,7 +1136,8 @@ export class MentorSlotService {
       throw new BadRequestException('Proposed slot is full.');
     }
 
-    this.enforceMinimumNotice(new Date(slot.slotStartDateTime));
+    // 12-hour reschedule notice is temporarily disabled for short-notice sessions.
+    // this.enforceMinimumNotice(new Date(slot.slotStartDateTime));
 
     if (new Date(slot.slotStartDateTime) <= new Date()) {
       throw new BadRequestException('Cannot reschedule to past slot.');
@@ -1246,7 +1248,7 @@ export class MentorSlotService {
   }
 
   /* ==========================================================================
-     ENFORCE 12-HOUR SLOT DELETION RULE
+     DELETE EMPTY UPCOMING SLOT
   ========================================================================== */
 
   async removeSlot(userId: number, slotId: number) {
@@ -1268,11 +1270,43 @@ export class MentorSlotService {
       throw new ForbiddenException('You do not own this slot.');
     }
 
-    this.enforceMinimumNotice(slot.slotStartDateTime);
+    if (new Date(slot.slotStartDateTime) <= new Date()) {
+      throw new BadRequestException('Only upcoming slots can be deleted.');
+    }
 
-    return db
+    if (slot.currentBookedCount > 0) {
+      throw new BadRequestException('Booked slots cannot be deleted.');
+    }
+
+    const [{ count: bookingCount }] = await db
+      .select({ count: count() })
+      .from(zuvyMentorSlotBooking)
+      .where(
+        and(
+          eq(zuvyMentorSlotBooking.slotAvailabilityId, slotId),
+          ne(zuvyMentorSlotBooking.status, 'cancelled'),
+        ),
+      );
+
+    if (Number(bookingCount) > 0) {
+      throw new BadRequestException('Booked slots cannot be deleted.');
+    }
+
+    // 12-hour deletion notice is temporarily disabled for short-notice slots.
+    // this.enforceMinimumNotice(slot.slotStartDateTime);
+
+    const result = await db
       .delete(zuvyMentorSlotAvailability)
-      .where(eq(zuvyMentorSlotAvailability.id, slotId));
+      .where(eq(zuvyMentorSlotAvailability.id, slotId))
+      .returning();
+
+    if (!result.length) {
+      throw new NotFoundException('Slot not found or already deleted');
+    }
+
+    return {
+      message: 'Slot deleted successfully',
+    };
   }
 
   async acceptReschedule(bookingId: number, mentorUserId?: number) {
@@ -1440,6 +1474,14 @@ export class MentorSlotService {
       throw new BadRequestException('Cannot create past slot.');
     }
 
+    const durationMinutes = Math.round(
+      (end.getTime() - start.getTime()) / (1000 * 60),
+    );
+
+    if (durationMinutes <= 0) {
+      throw new BadRequestException('Invalid slot duration.');
+    }
+
     /* ================================
        PLATFORM SLOT OVERLAP CHECK
     ================================= */
@@ -1453,8 +1495,8 @@ export class MentorSlotService {
             zuvyMentorSlotAvailability.mentorSlotManagementId,
             mentorProfile.id,
           ),
-          lt(zuvyMentorSlotAvailability.slotEndDateTime, start),
-          gt(zuvyMentorSlotAvailability.slotStartDateTime, end),
+          lt(zuvyMentorSlotAvailability.slotStartDateTime, end),
+          gt(zuvyMentorSlotAvailability.slotEndDateTime, start),
         ),
       );
 
@@ -1468,7 +1510,11 @@ export class MentorSlotService {
         mentorSlotManagementId: mentorProfile.id,
         slotStartDateTime: start,
         slotEndDateTime: end,
-        durationMinutes: dto.durationMinutes,
+        durationMinutes,
+        maxCapacity: dto.maxCapacity ?? 1,
+        topic: dto.topic ?? null,
+        status: 'available',
+        isPublic: true,
       } as typeof zuvyMentorSlotAvailability.$inferInsert)
       .returning();
   }

--- a/src/controller/mentor-slot/recurrence/mentor-recurrence.controller.ts
+++ b/src/controller/mentor-slot/recurrence/mentor-recurrence.controller.ts
@@ -32,13 +32,16 @@ export class MentorRecurrenceController {
     displayType: 'recurring mentor slots',
   })
   async generateRecurringSlots(@Req() req, @Body() dto: RecurrenceDto) {
-    return this.recurrenceService.generateRecurringSlots({
-      mentorSlotManagementId: dto.mentorSlotManagementId,
-      slotStart: new Date(dto.slotStart),
-      slotEnd: new Date(dto.slotEnd),
-      recurrenceRule: dto.recurrenceRule,
-      recurrenceEndDate: new Date(dto.recurrenceEndDate),
-      previewOnly: dto.previewOnly,
-    });
+    return this.recurrenceService.generateRecurringSlots(
+      {
+        mentorSlotManagementId: dto.mentorSlotManagementId,
+        slotStart: new Date(dto.slotStart),
+        slotEnd: new Date(dto.slotEnd),
+        recurrenceRule: dto.recurrenceRule,
+        recurrenceEndDate: new Date(dto.recurrenceEndDate),
+        previewOnly: dto.previewOnly,
+      },
+      Number(req.user[0].id),
+    );
   }
 }

--- a/src/controller/mentor-slot/recurrence/mentor-recurrence.service.ts
+++ b/src/controller/mentor-slot/recurrence/mentor-recurrence.service.ts
@@ -1,7 +1,15 @@
-import { Injectable, BadRequestException } from '@nestjs/common';
+import {
+  Injectable,
+  BadRequestException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
 import { RRule } from 'rrule';
 import { db } from '../../../db';
-import { zuvyMentorSlotAvailability } from '../../../../drizzle/schema';
+import {
+  zuvyMentorSlotAvailability,
+  zuvyMentorSlotManagement,
+} from '../../../../drizzle/schema';
 import { and, eq, sql } from 'drizzle-orm';
 
 @Injectable()
@@ -10,14 +18,17 @@ export class MentorRecurrenceService {
      GENERATE RECURRING SLOTS
   ========================================================================== */
 
-  async generateRecurringSlots(params: {
-    mentorSlotManagementId: number;
-    slotStart: Date;
-    slotEnd: Date;
-    recurrenceRule: string;
-    recurrenceEndDate: Date;
-    previewOnly?: boolean;
-  }) {
+  async generateRecurringSlots(
+    params: {
+      mentorSlotManagementId: number;
+      slotStart: Date;
+      slotEnd: Date;
+      recurrenceRule: string;
+      recurrenceEndDate: Date;
+      previewOnly?: boolean;
+    },
+    mentorUserId?: number,
+  ) {
     const {
       mentorSlotManagementId,
       slotStart,
@@ -28,6 +39,22 @@ export class MentorRecurrenceService {
     } = params;
 
     if (!recurrenceRule) throw new BadRequestException('RRULE is required');
+
+    if (mentorUserId) {
+      const [mentorProfile] = await db
+        .select()
+        .from(zuvyMentorSlotManagement)
+        .where(eq(zuvyMentorSlotManagement.id, mentorSlotManagementId))
+        .limit(1);
+
+      if (!mentorProfile) {
+        throw new NotFoundException('Mentor profile not found.');
+      }
+
+      if (mentorProfile.mentorUserId !== BigInt(mentorUserId)) {
+        throw new ForbiddenException('You do not own this mentor profile.');
+      }
+    }
 
     const rule = RRule.fromString(recurrenceRule);
 

--- a/src/controller/mentor-slot/student-mentor-slot.controller.ts
+++ b/src/controller/mentor-slot/student-mentor-slot.controller.ts
@@ -23,10 +23,12 @@ import { BookSlotDto } from './dto/book-slot.dto';
 import { CancelBookingDto } from './dto/cancel-booking.dto';
 import { ProposeRescheduleDto } from './dto/reschedule.dto';
 import { MentorSearchDto } from './public/dto/mentor-search.dto';
+import { SkipOrgCheck } from 'src/rbac/decorators/skip-org-check.decorator';
 
 @ApiTags('Student Mentor APIs')
 @ApiBearerAuth('JWT-auth')
 @UseGuards(JwtAuthGuard)
+@SkipOrgCheck()
 @Controller('student')
 export class StudentMentorSlotController {
   constructor(

--- a/src/controller/mentor-slot/student-mentor-slot.controller.ts
+++ b/src/controller/mentor-slot/student-mentor-slot.controller.ts
@@ -1,0 +1,166 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  ParseIntPipe,
+  Post,
+  Query,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiQuery,
+  ApiTags,
+} from '@nestjs/swagger';
+import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
+import { MentorSlotService } from './mentor-slot.service';
+import { SessionService } from './session/session.service';
+import { MentorPublicService } from './public/mentor-public.service';
+import { BookSlotDto } from './dto/book-slot.dto';
+import { CancelBookingDto } from './dto/cancel-booking.dto';
+import { ProposeRescheduleDto } from './dto/reschedule.dto';
+import { MentorSearchDto } from './public/dto/mentor-search.dto';
+
+@ApiTags('Student Mentor APIs')
+@ApiBearerAuth('JWT-auth')
+@UseGuards(JwtAuthGuard)
+@Controller('student')
+export class StudentMentorSlotController {
+  constructor(
+    private readonly mentorSlotService: MentorSlotService,
+    private readonly sessionService: SessionService,
+    private readonly mentorPublicService: MentorPublicService,
+  ) {}
+
+  @Get('mentors')
+  @ApiOperation({ summary: 'Search mentors available to students' })
+  async getMentors(@Req() req: any, @Query() query: MentorSearchDto) {
+    return this.mentorPublicService.getAllMentors(
+      query.limit,
+      query.offset,
+      query.role,
+      query.expertise,
+      query.title,
+      query.search,
+    );
+  }
+
+  @Get('mentors/:mentorUserId')
+  @ApiOperation({ summary: 'Get a mentor profile for students' })
+  getMentorProfile(@Param('mentorUserId') mentorUserId: number) {
+    return this.mentorPublicService.getMentorProfile(mentorUserId);
+  }
+
+  @Get('mentors/:mentorId/availability')
+  @ApiOperation({ summary: 'Get available slots for a mentor' })
+  getAvailableSlots(@Param('mentorId', ParseIntPipe) mentorId: number) {
+    return this.mentorPublicService.getAvailableSlots(mentorId);
+  }
+
+  @Post('mentor-slots/book')
+  @ApiOperation({ summary: 'Book an available mentor slot as a student' })
+  async bookSlot(@Req() req, @Body() dto: BookSlotDto) {
+    return this.mentorSlotService.bookSlot(Number(req.user[0].id), dto.slotId);
+  }
+
+  @Get('mentor-slots/my')
+  @ApiOperation({ summary: 'Get all mentor slot bookings for the student' })
+  async getStudentBookings(@Req() req) {
+    return this.mentorSlotService.getStudentBookings(Number(req.user[0].id));
+  }
+
+  @Get('mentor-slots/metrics')
+  @ApiOperation({ summary: 'Get student mentor booking quota and eligibility' })
+  async getStudentMetrics(@Req() req) {
+    return this.mentorSlotService.getStudentMetrics(Number(req.user[0].id));
+  }
+
+  @Post('mentor-slots/bookings/:bookingId/reschedule')
+  @ApiOperation({ summary: 'Request a reschedule for a student booking' })
+  async proposeReschedule(
+    @Req() req,
+    @Param('bookingId', ParseIntPipe) bookingId: number,
+    @Query('slotId') slotId: number,
+    @Body() body: ProposeRescheduleDto,
+  ) {
+    return this.mentorSlotService.proposeReschedule(
+      bookingId,
+      slotId,
+      body.reason,
+      Number(req.user[0].id),
+    );
+  }
+
+  @Post('mentor-slots/bookings/:bookingId/cancel')
+  @ApiOperation({ summary: 'Cancel a student mentor booking' })
+  async cancelBooking(
+    @Req() req,
+    @Param('bookingId', ParseIntPipe) bookingId: number,
+    @Body() dto: CancelBookingDto,
+  ) {
+    return this.mentorSlotService.cancelBooking(
+      bookingId,
+      dto.reason,
+      dto.cancelledBy,
+      Number(req.user[0].id),
+    );
+  }
+
+  @Get('mentor-slots/bookings/:bookingId/recordings')
+  @ApiOperation({ summary: 'Get recordings for a student mentor booking' })
+  async getBookingRecordings(
+    @Req() req,
+    @Param('bookingId', ParseIntPipe) bookingId: number,
+  ) {
+    return this.mentorSlotService.getBookingRecordings(
+      Number(req.user[0].id),
+      bookingId,
+    );
+  }
+
+  @Get('mentor-sessions/my')
+  @ApiOperation({ summary: 'Get mentor sessions booked by the student' })
+  @ApiQuery({
+    name: 'filter',
+    required: false,
+    enum: ['all', 'upcoming', 'completed', 'cancelled'],
+  })
+  @ApiQuery({
+    name: 'limit',
+    required: false,
+    type: Number,
+  })
+  @ApiQuery({
+    name: 'offset',
+    required: false,
+    type: Number,
+  })
+  async getMySessions(
+    @Req() req,
+    @Query('filter') filter?: string,
+    @Query('limit') limit = 10,
+    @Query('offset') offset = 0,
+  ) {
+    return this.sessionService.getStudentSessions(
+      BigInt(req.user[0].id),
+      filter,
+      Number(limit),
+      Number(offset),
+    );
+  }
+
+  @Get('mentor-sessions/:sessionId')
+  @ApiOperation({ summary: 'Get details for a student mentor session' })
+  async getSessionDetail(
+    @Req() req,
+    @Param('sessionId', ParseIntPipe) sessionId: number,
+  ) {
+    return this.sessionService.getSessionDetail(
+      sessionId,
+      BigInt(req.user[0].id),
+    );
+  }
+}


### PR DESCRIPTION
- Add student-facing mentor slot/session controllers
- Add instructor-facing mentor slot/session controllers
- Add student aliases for public mentor discovery APIs
- Preserve legacy mentor-slot routes for backward compatibility
- Enforce booking ownership for reschedule, attendance, feedback, completion, recurrence, and cancellation flows
- Add route migration documentation for frontend API updates
- Removed 12-hr rule.
- conditions modified for slot removal
- updated CreateSlot api and dto body
- removeSlots updated
- Permissions Guard added to mentor-slots