### PR TITLE
Feat/student and mentor dashboard

### DIFF
--- a/drizzle/migrations/0034_create_mentor_profile.sql
+++ b/drizzle/migrations/0034_create_mentor_profile.sql
@@ -1,0 +1,85 @@
+
+
+CREATE TABLE IF NOT EXISTS "zuvy_mentor_profile" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "mentor_user_id" bigint NOT NULL,
+  "email" varchar(255),
+  "title" varchar(255),
+  "bio" text,
+  "expertise" jsonb,
+  "past_experiences" text,
+  "created_at" timestamp with time zone DEFAULT now(),
+  "updated_at" timestamp with time zone DEFAULT now(),
+  CONSTRAINT "zuvy_mentor_profile_mentor_user_id_users_id_fk"
+    FOREIGN KEY ("mentor_user_id") REFERENCES "public"."users"("id") ON DELETE cascade
+);
+
+ALTER TABLE "zuvy_mentor_profile"
+DROP CONSTRAINT IF EXISTS "zuvy_mentor_profile_mentor_user_id_users_id_fk";
+
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_mentor_profile_user"
+  ON "zuvy_mentor_profile" USING btree ("mentor_user_id");
+
+INSERT INTO "zuvy_mentor_profile" (
+  "mentor_user_id",
+  "email",
+  "title",
+  "bio",
+  "expertise",
+  "past_experiences",
+  "created_at",
+  "updated_at"
+)
+SELECT DISTINCT ON (m."mentor_user_id")
+  m."mentor_user_id",
+  u."email",
+  m."title",
+  m."bio",
+  m."expertise",
+  m."past_experiences",
+  COALESCE(m."created_at", now()),
+  COALESCE(m."updated_at", now())
+FROM "zuvy_mentor_slot_management" m
+INNER JOIN "users" u ON u."id" = m."mentor_user_id"
+ORDER BY m."mentor_user_id", m."updated_at" DESC NULLS LAST, m."id" DESC
+ON CONFLICT ("mentor_user_id") DO UPDATE
+SET
+  "email" = EXCLUDED."email",
+  "title" = EXCLUDED."title",
+  "bio" = EXCLUDED."bio",
+  "expertise" = EXCLUDED."expertise",
+  "past_experiences" = EXCLUDED."past_experiences",
+  "updated_at" = EXCLUDED."updated_at"
+
+  
+
+SELECT m."mentor_user_id", COUNT(*) AS cnt
+FROM "zuvy_mentor_slot_management" m
+LEFT JOIN "users" u ON u."id" = m."mentor_user_id"
+WHERE u."id" IS NULL
+GROUP BY m."mentor_user_id"
+ORDER BY cnt DESC;
+
+UPDATE main.zuvy_mentor_slot_management m
+SET
+  title = p.title,
+  bio = p.bio,
+  expertise = p.expertise,
+  past_experiences = p.past_experiences,
+  updated_at = now()
+FROM main.zuvy_mentor_profile p
+WHERE p.mentor_user_id = m.mentor_user_id;
+
+SELECT mentor_user_id, email, title, bio, expertise, past_experiences
+FROM main.zuvy_mentor_profile
+LIMIT 20;
+
+SELECT mentor_user_id, organization_id, bootcamp_id, is_verified, timezone
+FROM main.zuvy_mentor_slot_management
+ORDER BY mentor_user_id, organization_id;
+
+SELECT m.mentor_user_id, m.organization_id
+FROM main.zuvy_mentor_slot_management m
+LEFT JOIN main.zuvy_mentor_profile p
+  ON p.mentor_user_id = m.mentor_user_id
+WHERE p.id IS NULL;

--- a/drizzle/migrations/0034_create_mentor_profile.sql
+++ b/drizzle/migrations/0034_create_mentor_profile.sql
@@ -11,11 +11,8 @@ CREATE TABLE IF NOT EXISTS "zuvy_mentor_profile" (
   "created_at" timestamp with time zone DEFAULT now(),
   "updated_at" timestamp with time zone DEFAULT now(),
   CONSTRAINT "zuvy_mentor_profile_mentor_user_id_users_id_fk"
-    FOREIGN KEY ("mentor_user_id") REFERENCES "public"."users"("id") ON DELETE cascade
+    FOREIGN KEY ("mentor_user_id") REFERENCES "main"."users"("id") ON DELETE cascade
 );
-
-ALTER TABLE "zuvy_mentor_profile"
-DROP CONSTRAINT IF EXISTS "zuvy_mentor_profile_mentor_user_id_users_id_fk";
 
 CREATE UNIQUE INDEX IF NOT EXISTS "idx_mentor_profile_user"
   ON "zuvy_mentor_profile" USING btree ("mentor_user_id");
@@ -69,6 +66,8 @@ SET
   updated_at = now()
 FROM main.zuvy_mentor_profile p
 WHERE p.mentor_user_id = m.mentor_user_id;
+
+--------------test------------------------
 
 SELECT mentor_user_id, email, title, bio, expertise, past_experiences
 FROM main.zuvy_mentor_profile

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -4666,6 +4666,31 @@ export const zuvyMentorSlotManagement = main.table(
   }),
 );
 
+export const zuvyMentorProfile = main.table(
+  'zuvy_mentor_profile',
+  {
+    id: serial('id').primaryKey().notNull(),
+
+    mentorUserId: bigserial('mentor_user_id', { mode: 'bigint' })
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+
+    email: varchar('email', { length: 255 }),
+    title: varchar('title', { length: 255 }),
+    bio: text('bio'),
+    expertise: jsonb('expertise'),
+    pastExperiences: text('past_experiences'),
+
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow(),
+  },
+  (table) => ({
+    mentorUserUniqueIdx: uniqueIndex('idx_mentor_profile_user').on(
+      table.mentorUserId,
+    ),
+  }),
+);
+
 /* ============================================================================
    SLOT AVAILABILITY
 ============================================================================ */

--- a/src/controller/mentor-slot/dto/update-mentor-profile.dto.ts
+++ b/src/controller/mentor-slot/dto/update-mentor-profile.dto.ts
@@ -29,10 +29,4 @@ export class UpdateMentorProfileDto {
     example: 'Full Stack Developer',
   })
   title: string;
-
-  @ApiProperty({
-    example: 1,
-    required: false,
-  })
-  bootcampId?: number;
 }

--- a/src/controller/mentor-slot/instructor-mentor-slot.controller.ts
+++ b/src/controller/mentor-slot/instructor-mentor-slot.controller.ts
@@ -45,13 +45,21 @@ export class InstructorMentorSlotController {
   @Post('mentor-slots/create')
   @ApiOperation({ summary: 'Create a mentor availability slot as instructor' })
   async createSlot(@Req() req, @Body() dto: CreateSlotDto) {
-    return this.mentorSlotService.createSlot(Number(req.user[0].id), dto);
+    return this.mentorSlotService.createSlot(
+      Number(req.user[0].id),
+      dto,
+      Number(req.user[0].orgId),
+    );
   }
 
   @Delete('mentor-slots/:slotId')
   @ApiOperation({ summary: 'Delete an instructor-owned mentor slot' })
   async removeSlot(@Req() req, @Param('slotId', ParseIntPipe) slotId: number) {
-    return this.mentorSlotService.removeSlot(Number(req.user[0].id), slotId);
+    return this.mentorSlotService.removeSlot(
+      Number(req.user[0].id),
+      slotId,
+      Number(req.user[0].orgId),
+    );
   }
 
   @Get('mentor-slots/my')
@@ -70,6 +78,7 @@ export class InstructorMentorSlotController {
       Number(req.user[0].id),
       Number(weekOffset),
       sort,
+      Number(req.user[0].orgId),
     );
   }
 
@@ -82,6 +91,7 @@ export class InstructorMentorSlotController {
     return this.mentorSlotService.getSlotDetails(
       Number(req.user[0].id),
       slotId,
+      Number(req.user[0].orgId),
     );
   }
 
@@ -188,13 +198,17 @@ export class InstructorMentorSlotController {
     return this.mentorSlotService.updateMentorProfile(
       Number(req.user[0].id),
       dto,
+      Number(req.user[0].orgId),
     );
   }
 
   @Get('mentor-slots/profile')
   @ApiOperation({ summary: 'Get the instructor mentor profile' })
   async getMyProfile(@Req() req) {
-    return this.mentorSlotService.getMyMentorProfile(Number(req.user[0].id));
+    return this.mentorSlotService.getMyMentorProfile(
+      Number(req.user[0].id),
+      Number(req.user[0].orgId),
+    );
   }
 
   @Post('mentor-slots/profile')
@@ -203,13 +217,17 @@ export class InstructorMentorSlotController {
     return this.mentorSlotService.createOrUpdateMentorProfile(
       Number(req.user[0].id),
       dto,
+      Number(req.user[0].orgId),
     );
   }
 
   @Get('mentor-slots/metrics')
   @ApiOperation({ summary: 'Get mentor metrics for the instructor' })
   async getMyMetrics(@Req() req) {
-    return this.metricsService.getMentorMetrics(BigInt(req.user[0].id));
+    return this.metricsService.getMentorMetrics(
+      BigInt(req.user[0].id),
+      Number(req.user[0].orgId),
+    );
   }
 
   @Post('mentor-slots/recurrence')

--- a/src/controller/mentor-slot/mentor-slot.controller.ts
+++ b/src/controller/mentor-slot/mentor-slot.controller.ts
@@ -188,7 +188,11 @@ export class MentorSlotController {
     displayType: 'mentor slot',
   })
   async createSlot(@Req() req, @Body() dto: CreateSlotDto) {
-    return this.mentorSlotService.createSlot(Number(req.user[0].id), dto);
+    return this.mentorSlotService.createSlot(
+      Number(req.user[0].id),
+      dto,
+      Number(req.user[0].orgId),
+    );
   }
 
   /* ==========================================================================
@@ -203,7 +207,11 @@ export class MentorSlotController {
     displayType: 'mentor slot',
   })
   async removeSlot(@Req() req, @Param('slotId', ParseIntPipe) slotId: number) {
-    return this.mentorSlotService.removeSlot(Number(req.user[0].id), slotId);
+    return this.mentorSlotService.removeSlot(
+      Number(req.user[0].id),
+      slotId,
+      Number(req.user[0].orgId),
+    );
   }
 
   /* ==========================================================================  
@@ -224,6 +232,7 @@ export class MentorSlotController {
       Number(req.user[0].id),
       Number(weekOffset),
       sort,
+      Number(req.user[0].orgId),
     );
   }
 
@@ -238,6 +247,7 @@ export class MentorSlotController {
     return this.mentorSlotService.getSlotDetails(
       Number(req.user[0].id),
       slotId,
+      Number(req.user[0].orgId),
     );
   }
 
@@ -327,6 +337,7 @@ export class MentorSlotController {
     return this.mentorSlotService.updateMentorProfile(
       Number(req.user[0].id),
       dto,
+      Number(req.user[0].orgId),
     );
   }
 
@@ -337,7 +348,10 @@ export class MentorSlotController {
   @Get('mentor/profile')
   @ApiOperation({ summary: 'Get logged-in mentor profile' })
   async getMyProfile(@Req() req) {
-    return this.mentorSlotService.getMyMentorProfile(Number(req.user[0].id));
+    return this.mentorSlotService.getMyMentorProfile(
+      Number(req.user[0].id),
+      Number(req.user[0].orgId),
+    );
   }
 
   /* ==========================================================================  
@@ -358,6 +372,10 @@ export class MentorSlotController {
       throw new BadRequestException('Invalid userId');
     }
 
-    return this.mentorSlotService.createOrUpdateMentorProfile(userId, dto);
+    return this.mentorSlotService.createOrUpdateMentorProfile(
+      userId,
+      dto,
+      Number(req.user[0].orgId),
+    );
   }
 }

--- a/src/controller/mentor-slot/mentor-slot.service.ts
+++ b/src/controller/mentor-slot/mentor-slot.service.ts
@@ -1551,6 +1551,13 @@ export class MentorSlotService {
     const endOfWeek = new Date(startOfWeek);
     endOfWeek.setDate(startOfWeek.getDate() + 7);
 
+    /* ==================================================
+      DISPLAY END OF WEEK (SUNDAY 23:59:59)
+    ================================================== */
+
+    const displayWeekEnd = new Date(endOfWeek);
+    displayWeekEnd.setMilliseconds(displayWeekEnd.getMilliseconds() - 1);
+
     /* ============================
        FETCH SLOTS
     ============================ */
@@ -1630,7 +1637,7 @@ export class MentorSlotService {
 
     return {
       weekStart: startOfWeek,
-      weekEnd: endOfWeek,
+      weekEnd: displayWeekEnd,
       metrics,
       slots: processedSlots,
     };

--- a/src/controller/mentor-slot/mentor-slot.service.ts
+++ b/src/controller/mentor-slot/mentor-slot.service.ts
@@ -10,12 +10,15 @@ import {
   zuvyMentorSlotAvailability,
   zuvyMentorSlotBooking,
   zuvyMentorSlotManagement,
+  zuvyMentorProfile,
   zuvyUserRolesAssigned,
   zuvyUserRoles,
+  zuvyBatches,
   zuvyBatchEnrollments,
   zuvyBootcampType,
   zuvyBootcamps,
   zuvyMentorSessionRecordings,
+  zuvyOrganizations,
   users,
   zuvyStudentBookingMetrics,
 } from '../../../drizzle/schema';
@@ -44,14 +47,12 @@ export class MentorSlotService {
     return booking.meetingLink;
   }
 
-  async getOrCreateMentorProfile(userId: number) {
+  private async resolveInstructorOrganization(
+    userId: number,
+    preferredOrganizationId?: number,
+  ) {
     const userIdBigInt = BigInt(userId);
-
-    /* ========================================
-       1. FETCH INSTRUCTOR ROLE + ORG
-    ======================================== */
-
-    const roleAssignment = await db
+    const roleAssignments = await db
       .select({
         organizationId: zuvyUserRolesAssigned.organizationId,
       })
@@ -65,16 +66,82 @@ export class MentorSlotService {
           eq(zuvyUserRolesAssigned.userId, userIdBigInt),
           eq(zuvyUserRoles.name, 'instructor'),
         ),
-      )
-      .limit(1);
+      );
 
-    if (!roleAssignment.length || !roleAssignment[0].organizationId) {
+    const validOrganizationIds = roleAssignments
+      .map((assignment) => assignment.organizationId)
+      .filter((organizationId): organizationId is number => !!organizationId);
+
+    if (!validOrganizationIds.length) {
       throw new BadRequestException(
         'User is not an instructor or organization not assigned.',
       );
     }
 
-    const organizationId = roleAssignment[0].organizationId;
+    if (preferredOrganizationId !== undefined) {
+      if (!validOrganizationIds.includes(preferredOrganizationId)) {
+        throw new ForbiddenException(
+          'Instructor is not assigned to the selected organization.',
+        );
+      }
+
+      return preferredOrganizationId;
+    }
+
+    return validOrganizationIds[0];
+  }
+
+  private async getOrCreateSharedMentorProfile(userId: number) {
+    const userIdBigInt = BigInt(userId);
+    const [userRow] = await db
+      .select({ email: users.email })
+      .from(users)
+      .where(eq(users.id, userIdBigInt))
+      .limit(1);
+
+    if (!userRow) {
+      throw new NotFoundException('Mentor user not found');
+    }
+
+    let profile = await db.query.zuvyMentorProfile.findFirst({
+      where: eq(zuvyMentorProfile.mentorUserId, userIdBigInt),
+    });
+
+    if (!profile) {
+      const [createdProfile] = await db
+        .insert(zuvyMentorProfile)
+        .values({
+          mentorUserId: userIdBigInt,
+          email: userRow.email,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        } as typeof zuvyMentorProfile.$inferInsert)
+        .returning();
+
+      profile = createdProfile;
+    } else if (profile.email !== userRow.email) {
+      const [updatedProfile] = await db
+        .update(zuvyMentorProfile)
+        .set({
+          email: userRow.email,
+          updatedAt: new Date(),
+        } as Partial<typeof zuvyMentorProfile.$inferInsert>)
+        .where(eq(zuvyMentorProfile.id, profile.id))
+        .returning();
+
+      profile = updatedProfile;
+    }
+
+    return profile;
+  }
+
+  async getOrCreateMentorProfile(userId: number, organizationId?: number) {
+    const userIdBigInt = BigInt(userId);
+    await this.getOrCreateSharedMentorProfile(userId);
+    const resolvedOrganizationId = await this.resolveInstructorOrganization(
+      userId,
+      organizationId,
+    );
 
     /* ========================================
        2. CHECK IF MENTOR EXISTS
@@ -83,7 +150,7 @@ export class MentorSlotService {
     let mentor = await db.query.zuvyMentorSlotManagement.findFirst({
       where: and(
         eq(zuvyMentorSlotManagement.mentorUserId, userIdBigInt),
-        eq(zuvyMentorSlotManagement.organizationId, organizationId),
+        eq(zuvyMentorSlotManagement.organizationId, resolvedOrganizationId),
       ),
     });
 
@@ -96,7 +163,7 @@ export class MentorSlotService {
         .insert(zuvyMentorSlotManagement)
         .values({
           mentorUserId: userIdBigInt,
-          organizationId,
+          organizationId: resolvedOrganizationId,
           mentorType: 'instructor',
           status: 'active',
           isVerified: false,
@@ -191,16 +258,17 @@ export class MentorSlotService {
     return booking;
   }
 
-  private async ensureMentorZoomVerified(userId: number) {
-    const mentorProfile = await this.getOrCreateMentorProfile(userId);
+  private async ensureMentorZoomVerified(
+    userId: number,
+    organizationId?: number,
+  ) {
+    const mentorProfile = await this.getOrCreateMentorProfile(
+      userId,
+      organizationId,
+    );
     console.log(
       `Mentor profile for user ${userId}: isVerified=${mentorProfile?.isVerified}`,
     );
-
-    if (mentorProfile?.isVerified) {
-      console.log(`Mentor ${userId} already verified, skipping Zoom check`);
-      return true;
-    }
 
     const [userRow] = await db
       .select({ email: users.email })
@@ -220,6 +288,14 @@ export class MentorSlotService {
     );
 
     if (!zoomResponse.success) {
+      await db
+        .update(zuvyMentorSlotManagement)
+        .set({
+          isVerified: false,
+          updatedAt: new Date(),
+        } as Partial<typeof zuvyMentorSlotManagement.$inferInsert>)
+        .where(eq(zuvyMentorSlotManagement.id, mentorProfile.id));
+
       console.error(
         `Zoom user check failed for ${userRow.email}: ${zoomResponse.error}`,
       );
@@ -233,6 +309,14 @@ export class MentorSlotService {
     console.log(`Zoom user type=${userType}, status=${userStatus}`);
 
     if (userType !== 2 || userStatus !== 'active') {
+      await db
+        .update(zuvyMentorSlotManagement)
+        .set({
+          isVerified: false,
+          updatedAt: new Date(),
+        } as Partial<typeof zuvyMentorSlotManagement.$inferInsert>)
+        .where(eq(zuvyMentorSlotManagement.id, mentorProfile.id));
+
       console.error(
         `Zoom user not licensed/active: type=${userType}, status=${userStatus}`,
       );
@@ -251,20 +335,41 @@ export class MentorSlotService {
         isVerified: true,
         updatedAt: new Date(),
       } as Partial<typeof zuvyMentorSlotManagement.$inferInsert>)
-      .where(eq(zuvyMentorSlotManagement.mentorUserId, BigInt(userId)));
+      .where(eq(zuvyMentorSlotManagement.id, mentorProfile.id));
 
     return true;
   }
 
-  private async validateMentorProfileComplete(userId: number) {
+  private async validateMentorProfileComplete(
+    userId: number,
+    organizationId?: number,
+  ) {
+    const mentorProfile = await this.getOrCreateMentorProfile(
+      userId,
+      organizationId,
+    );
+    const sharedProfile = await this.getOrCreateSharedMentorProfile(userId);
+
     const [profile] = await db
       .select({
-        bio: zuvyMentorSlotManagement.bio,
-        expertise: zuvyMentorSlotManagement.expertise,
-        pastExperiences: zuvyMentorSlotManagement.pastExperiences,
+        bio: zuvyMentorProfile.bio,
+        expertise: zuvyMentorProfile.expertise,
+        pastExperiences: zuvyMentorProfile.pastExperiences,
       })
-      .from(zuvyMentorSlotManagement)
-      .where(eq(zuvyMentorSlotManagement.mentorUserId, BigInt(userId)))
+      .from(zuvyMentorProfile)
+      .innerJoin(
+        zuvyMentorSlotManagement,
+        eq(
+          zuvyMentorSlotManagement.mentorUserId,
+          zuvyMentorProfile.mentorUserId,
+        ),
+      )
+      .where(
+        and(
+          eq(zuvyMentorProfile.id, sharedProfile.id),
+          eq(zuvyMentorSlotManagement.id, mentorProfile.id),
+        ),
+      )
       .limit(1);
 
     if (!profile) {
@@ -291,6 +396,58 @@ export class MentorSlotService {
     }
 
     return true;
+  }
+
+  private async ensureMentorHasMentorshipEnabledBootcamp(
+    userId: number,
+    organizationId?: number,
+  ) {
+    const resolvedOrganizationId = await this.resolveInstructorOrganization(
+      userId,
+      organizationId,
+    );
+
+    const eligibleBootcamps = await db
+      .select({
+        bootcampId: zuvyBatches.bootcampId,
+      })
+      .from(zuvyBatches)
+      .innerJoin(zuvyBootcamps, eq(zuvyBatches.bootcampId, zuvyBootcamps.id))
+      .innerJoin(
+        zuvyBootcampType,
+        eq(zuvyBootcampType.bootcampId, zuvyBootcamps.id),
+      )
+      .where(
+        and(
+          eq(zuvyBatches.instructorId, userId),
+          eq(zuvyBootcamps.organizationId, resolvedOrganizationId),
+          eq(zuvyBootcampType.mentorshipEnabled, true),
+        ),
+      )
+      .limit(1);
+
+    if (!eligibleBootcamps.length || !eligibleBootcamps[0].bootcampId) {
+      throw new ForbiddenException(
+        'You are not assigned to any mentorship-enabled bootcamp in this organization.',
+      );
+    }
+
+    const mentorProfile = await this.getOrCreateMentorProfile(
+      userId,
+      resolvedOrganizationId,
+    );
+
+    if (!mentorProfile.bootcampId) {
+      await db
+        .update(zuvyMentorSlotManagement)
+        .set({
+          bootcampId: eligibleBootcamps[0].bootcampId,
+          updatedAt: new Date(),
+        } as Partial<typeof zuvyMentorSlotManagement.$inferInsert>)
+        .where(eq(zuvyMentorSlotManagement.id, mentorProfile.id));
+    }
+
+    return eligibleBootcamps[0].bootcampId;
   }
   /* ==========================================================================
      UTILITY — 12 HOUR RULE ENFORCER
@@ -1251,10 +1408,13 @@ export class MentorSlotService {
      DELETE EMPTY UPCOMING SLOT
   ========================================================================== */
 
-  async removeSlot(userId: number, slotId: number) {
+  async removeSlot(userId: number, slotId: number, organizationId?: number) {
     await this.ensureUserIsMentor(userId);
 
-    const mentorProfile = await this.getOrCreateMentorProfile(userId);
+    const mentorProfile = await this.getOrCreateMentorProfile(
+      userId,
+      organizationId,
+    );
 
     const [slot] = await db
       .select()
@@ -1456,12 +1616,16 @@ export class MentorSlotService {
     return { message: 'Reschedule declined.' };
   }
 
-  async createSlot(userId: number, dto: any) {
+  async createSlot(userId: number, dto: any, organizationId?: number) {
     await this.ensureUserIsMentor(userId);
-    await this.validateMentorProfileComplete(userId);
-    await this.ensureMentorZoomVerified(userId);
+    await this.validateMentorProfileComplete(userId, organizationId);
+    await this.ensureMentorHasMentorshipEnabledBootcamp(userId, organizationId);
+    await this.ensureMentorZoomVerified(userId, organizationId);
 
-    const mentorProfile = await this.getOrCreateMentorProfile(userId);
+    const mentorProfile = await this.getOrCreateMentorProfile(
+      userId,
+      organizationId,
+    );
 
     const start = new Date(dto.slotStartDateTime);
     const end = new Date(dto.slotEndDateTime);
@@ -1523,15 +1687,19 @@ export class MentorSlotService {
     userId: number,
     weekOffset = 0,
     sort: 'asc' | 'desc' = 'desc',
+    organizationId?: number,
   ) {
     await this.ensureUserIsMentor(userId);
 
-    const mentorProfile = await this.getOrCreateMentorProfile(userId);
+    const mentorProfile = await this.getOrCreateMentorProfile(
+      userId,
+      organizationId,
+    );
 
     if (!mentorProfile) {
       throw new NotFoundException('Mentor profile not found.');
     }
-    await this.ensureMentorZoomVerified(userId);
+    await this.ensureMentorZoomVerified(userId, organizationId);
 
     const now = new Date();
 
@@ -1643,10 +1811,17 @@ export class MentorSlotService {
     };
   }
 
-  async getSlotDetails(userId: number, slotId: number) {
+  async getSlotDetails(
+    userId: number,
+    slotId: number,
+    organizationId?: number,
+  ) {
     await this.ensureUserIsMentor(userId);
 
-    const mentorProfile = await this.getOrCreateMentorProfile(userId);
+    const mentorProfile = await this.getOrCreateMentorProfile(
+      userId,
+      organizationId,
+    );
 
     const [slot] = await db
       .select()
@@ -1814,12 +1989,13 @@ export class MentorSlotService {
       .where(eq(zuvyMentorSlotBooking.id, bookingId));
   }
 
-  async updateMentorProfile(userId: number, dto: any) {
+  async updateMentorProfile(userId: number, dto: any, organizationId?: number) {
     await this.ensureUserIsMentor(userId);
 
-    const userIdBigInt = BigInt(userId);
-    const updatePayload: Partial<typeof zuvyMentorSlotManagement.$inferSelect> =
-      {};
+    await this.resolveInstructorOrganization(userId, organizationId);
+    const sharedProfile = await this.getOrCreateSharedMentorProfile(userId);
+
+    const updatePayload: Partial<typeof zuvyMentorProfile.$inferSelect> = {};
 
     if (dto.bio !== undefined) updatePayload.bio = dto.bio;
     if (dto.expertise !== undefined) updatePayload.expertise = dto.expertise;
@@ -1827,53 +2003,46 @@ export class MentorSlotService {
     if (dto.pastExperiences !== undefined)
       updatePayload.pastExperiences = dto.pastExperiences;
 
-    if (dto.bootcampId !== undefined) {
-      const [bootcamp] = await db
-        .select()
-        .from(zuvyBootcamps)
-        .where(eq(zuvyBootcamps.id, dto.bootcampId))
-        .limit(1);
-
-      if (!bootcamp) {
-        throw new BadRequestException('Invalid bootcampId');
-      }
-
-      updatePayload.bootcampId = dto.bootcampId;
-    }
-
     // prevent empty update
     if (Object.keys(updatePayload).length === 0) {
       throw new BadRequestException('No fields provided for update');
     }
 
     await db
-      .update(zuvyMentorSlotManagement)
+      .update(zuvyMentorProfile)
       .set({
         ...updatePayload,
         updatedAt: new Date(),
-      } as Partial<typeof zuvyMentorSlotManagement.$inferInsert>)
-      .where(eq(zuvyMentorSlotManagement.mentorUserId, userIdBigInt));
+      } as Partial<typeof zuvyMentorProfile.$inferInsert>)
+      .where(eq(zuvyMentorProfile.id, sharedProfile.id));
     return { message: ' Mentor profile updated successfully' };
   }
 
-  async getMyMentorProfile(userId: number) {
+  async getMyMentorProfile(userId: number, organizationId?: number) {
     await this.ensureUserIsMentor(userId);
+    await this.getOrCreateSharedMentorProfile(userId);
 
     const userIdBigInt = BigInt(userId);
+    const resolvedOrganizationId = await this.resolveInstructorOrganization(
+      userId,
+      organizationId,
+    );
 
     const [profile] = await db
       .select({
         mentorProfileId: zuvyMentorSlotManagement.id,
         mentorUserId: zuvyMentorSlotManagement.mentorUserId,
         organizationId: zuvyMentorSlotManagement.organizationId,
+        orgName: zuvyOrganizations.displayName,
 
         mentorType: zuvyMentorSlotManagement.mentorType,
         timezone: zuvyMentorSlotManagement.timezone,
 
-        title: zuvyMentorSlotManagement.title,
-        bio: zuvyMentorSlotManagement.bio,
-        expertise: zuvyMentorSlotManagement.expertise,
-        pastExperiences: zuvyMentorSlotManagement.pastExperiences,
+        title: zuvyMentorProfile.title,
+        bio: zuvyMentorProfile.bio,
+        expertise: zuvyMentorProfile.expertise,
+        pastExperiences: zuvyMentorProfile.pastExperiences,
+        bootcampId: zuvyMentorSlotManagement.bootcampId,
 
         status: zuvyMentorSlotManagement.status,
         isVerified: zuvyMentorSlotManagement.isVerified,
@@ -1883,7 +2052,23 @@ export class MentorSlotService {
         updatedAt: zuvyMentorSlotManagement.updatedAt,
       })
       .from(zuvyMentorSlotManagement)
-      .where(eq(zuvyMentorSlotManagement.mentorUserId, userIdBigInt))
+      .innerJoin(
+        zuvyMentorProfile,
+        eq(
+          zuvyMentorProfile.mentorUserId,
+          zuvyMentorSlotManagement.mentorUserId,
+        ),
+      )
+      .innerJoin(
+        zuvyOrganizations,
+        eq(zuvyOrganizations.id, zuvyMentorSlotManagement.organizationId),
+      )
+      .where(
+        and(
+          eq(zuvyMentorSlotManagement.mentorUserId, userIdBigInt),
+          eq(zuvyMentorSlotManagement.organizationId, resolvedOrganizationId),
+        ),
+      )
       .limit(1);
 
     if (!profile) {
@@ -1924,36 +2109,18 @@ export class MentorSlotService {
     }
   }
 
-  async createOrUpdateMentorProfile(userId: number, dto: any) {
+  async createOrUpdateMentorProfile(
+    userId: number,
+    dto: any,
+    organizationId?: number,
+  ) {
     await this.ensureUserIsMentor(userId);
 
     const userIdBigInt = BigInt(userId);
-
-    /* =========================================================
-    FETCH ORGANIZATION FROM DB TO ENSURE USER IS INSTRUCTOR IN AN ORG
-    ========================================================= */
-    const roleAssignment = await db
-      .select({
-        organizationId: zuvyUserRolesAssigned.organizationId,
-      })
-      .from(zuvyUserRolesAssigned)
-      .innerJoin(
-        zuvyUserRoles,
-        eq(zuvyUserRolesAssigned.roleId, zuvyUserRoles.id),
-      )
-      .where(
-        and(
-          eq(zuvyUserRolesAssigned.userId, userIdBigInt),
-          eq(zuvyUserRoles.name, 'instructor'),
-        ),
-      )
-      .limit(1);
-
-    if (!roleAssignment.length || !roleAssignment[0].organizationId) {
-      throw new BadRequestException('Organization not found for instructor');
-    }
-
-    const organizationId = roleAssignment[0].organizationId;
+    const resolvedOrganizationId = await this.resolveInstructorOrganization(
+      userId,
+      organizationId,
+    );
 
     /* =========================================================
     FETCH EXISTING PROFILE
@@ -1961,24 +2128,10 @@ export class MentorSlotService {
     const existingProfile = await db.query.zuvyMentorSlotManagement.findFirst({
       where: and(
         eq(zuvyMentorSlotManagement.mentorUserId, userIdBigInt),
-        eq(zuvyMentorSlotManagement.organizationId, organizationId),
+        eq(zuvyMentorSlotManagement.organizationId, resolvedOrganizationId),
       ),
     });
-
-    /* =========================================================
-    VALIDATE BOOTCAMP
-    ========================================================= */
-    if (dto.bootcampId !== undefined) {
-      const [bootcamp] = await db
-        .select()
-        .from(zuvyBootcamps)
-        .where(eq(zuvyBootcamps.id, dto.bootcampId))
-        .limit(1);
-
-      if (!bootcamp) {
-        throw new BadRequestException('Invalid bootcampId');
-      }
-    }
+    const sharedProfile = await this.getOrCreateSharedMentorProfile(userId);
 
     /* =========================================================
     PREPARE PAYLOAD
@@ -1990,7 +2143,6 @@ export class MentorSlotService {
       ...(dto.pastExperiences !== undefined && {
         pastExperiences: dto.pastExperiences,
       }),
-      ...(dto.bootcampId !== undefined && { bootcampId: dto.bootcampId }),
     };
 
     /* =========================================================
@@ -2001,15 +2153,9 @@ export class MentorSlotService {
         .insert(zuvyMentorSlotManagement)
         .values({
           mentorUserId: userIdBigInt,
-          organizationId,
+          organizationId: resolvedOrganizationId,
 
           mentorType: 'instructor',
-
-          bio: dto.bio ?? null,
-          expertise: dto.expertise ?? [],
-          title: dto.title ?? null,
-          pastExperiences: dto.pastExperiences ?? null,
-          bootcampId: dto.bootcampId ?? null,
 
           isBufferEnabled: false,
           bufferMinutes: 0,
@@ -2028,6 +2174,16 @@ export class MentorSlotService {
         } as typeof zuvyMentorSlotManagement.$inferInsert)
         .returning();
 
+      if (Object.keys(payload).length > 0) {
+        await db
+          .update(zuvyMentorProfile)
+          .set({
+            ...payload,
+            updatedAt: new Date(),
+          } as Partial<typeof zuvyMentorProfile.$inferInsert>)
+          .where(eq(zuvyMentorProfile.id, sharedProfile.id));
+      }
+
       return {
         message: 'Mentor profile created successfully',
         data: newProfile,
@@ -2042,17 +2198,12 @@ export class MentorSlotService {
     }
 
     const result = await db
-      .update(zuvyMentorSlotManagement)
+      .update(zuvyMentorProfile)
       .set({
         ...payload,
         updatedAt: new Date(),
-      } as Partial<typeof zuvyMentorSlotManagement.$inferInsert>)
-      .where(
-        and(
-          eq(zuvyMentorSlotManagement.mentorUserId, userIdBigInt),
-          eq(zuvyMentorSlotManagement.organizationId, organizationId),
-        ),
-      )
+      } as Partial<typeof zuvyMentorProfile.$inferInsert>)
+      .where(eq(zuvyMentorProfile.id, sharedProfile.id))
       .returning();
 
     if (!result.length) {

--- a/src/controller/mentor-slot/metrics/mentor-metrics.controller.ts
+++ b/src/controller/mentor-slot/metrics/mentor-metrics.controller.ts
@@ -12,6 +12,9 @@ export class MentorMetricsController {
 
   @Get('me')
   async getMyMetrics(@Req() req) {
-    return this.metricsService.getMentorMetrics(BigInt(req.user[0].id));
+    return this.metricsService.getMentorMetrics(
+      BigInt(req.user[0].id),
+      Number(req.user[0].orgId),
+    );
   }
 }

--- a/src/controller/mentor-slot/metrics/mentor-metrics.service.ts
+++ b/src/controller/mentor-slot/metrics/mentor-metrics.service.ts
@@ -8,7 +8,17 @@ import { and, eq, sql } from 'drizzle-orm';
 
 @Injectable()
 export class MentorMetricsService {
-  async getMentorMetrics(mentorUserId: bigint) {
+  async getMentorMetrics(mentorUserId: bigint, organizationId?: number) {
+    const bookingConditions = [
+      eq(zuvyMentorSlotBooking.mentorUserId, mentorUserId),
+    ];
+
+    if (organizationId !== undefined) {
+      bookingConditions.push(
+        eq(zuvyMentorSlotBooking.organizationId, organizationId),
+      );
+    }
+
     /* ==========================================================
        SESSION COUNTS
     ========================================================== */
@@ -21,7 +31,7 @@ export class MentorMetricsService {
         missed: sql<number>`COUNT(*) FILTER (WHERE session_lifecycle_state = 'MISSED')`,
       })
       .from(zuvyMentorSlotBooking)
-      .where(eq(zuvyMentorSlotBooking.mentorUserId, mentorUserId));
+      .where(and(...bookingConditions));
 
     const total = sessionCounts.total || 0;
     const completed = sessionCounts.completed || 0;
@@ -42,7 +52,7 @@ export class MentorMetricsService {
         ratingCount: sql<number>`COUNT(mentor_rating)`,
       })
       .from(zuvyMentorSlotBooking)
-      .where(eq(zuvyMentorSlotBooking.mentorUserId, mentorUserId));
+      .where(and(...bookingConditions));
 
     /* ==========================================================
        UPCOMING SESSIONS
@@ -55,7 +65,7 @@ export class MentorMetricsService {
       .from(zuvyMentorSlotBooking)
       .where(
         and(
-          eq(zuvyMentorSlotBooking.mentorUserId, mentorUserId),
+          ...bookingConditions,
           eq(zuvyMentorSlotBooking.sessionLifecycleState, 'SCHEDULED'),
           sql`${zuvyMentorSlotBooking.slotAvailabilityId} IN (
         SELECT ${zuvyMentorSlotAvailability.id}
@@ -76,7 +86,13 @@ export class MentorMetricsService {
       })
       .from(zuvyMentorSlotAvailability)
       .where(
-        sql`${zuvyMentorSlotAvailability.mentorSlotManagementId} IN (
+        organizationId !== undefined
+          ? sql`${zuvyMentorSlotAvailability.mentorSlotManagementId} IN (
+    SELECT id FROM zuvy_mentor_slot_management
+    WHERE mentor_user_id = ${mentorUserId}
+      AND organization_id = ${organizationId}
+  )`
+          : sql`${zuvyMentorSlotAvailability.mentorSlotManagementId} IN (
     SELECT id FROM zuvy_mentor_slot_management
     WHERE mentor_user_id = ${mentorUserId}
   )`,

--- a/src/controller/mentor-slot/public/dto/mentor-search.dto.ts
+++ b/src/controller/mentor-slot/public/dto/mentor-search.dto.ts
@@ -18,4 +18,7 @@ export class MentorSearchDto {
 
   @ApiPropertyOptional()
   search?: string;
+
+  @ApiPropertyOptional({ example: 12 })
+  organizationId?: number;
 }

--- a/src/controller/mentor-slot/public/mentor-public.controller.ts
+++ b/src/controller/mentor-slot/public/mentor-public.controller.ts
@@ -24,16 +24,29 @@ export class MentorPublicController {
       query.expertise,
       query.title,
       query.search,
+      query.organizationId ? Number(query.organizationId) : undefined,
     );
   }
 
   @Get(':mentorUserId')
-  getMentorProfile(@Param('mentorUserId') mentorUserId: number) {
-    return this.service.getMentorProfile(mentorUserId);
+  getMentorProfile(
+    @Param('mentorUserId') mentorUserId: number,
+    @Query('organizationId') organizationId?: number,
+  ) {
+    return this.service.getMentorProfile(
+      mentorUserId,
+      organizationId ? Number(organizationId) : undefined,
+    );
   }
 
   @Get(':mentorId/availability')
-  getAvailableSlots(@Param('mentorId', ParseIntPipe) mentorId: number) {
-    return this.service.getAvailableSlots(mentorId);
+  getAvailableSlots(
+    @Param('mentorId', ParseIntPipe) mentorId: number,
+    @Query('organizationId') organizationId?: number,
+  ) {
+    return this.service.getAvailableSlots(
+      mentorId,
+      organizationId ? Number(organizationId) : undefined,
+    );
   }
 }

--- a/src/controller/mentor-slot/public/mentor-public.service.ts
+++ b/src/controller/mentor-slot/public/mentor-public.service.ts
@@ -5,12 +5,13 @@ import {
   users,
   zuvyUserRolesAssigned,
   zuvyUserRoles,
+  zuvyMentorProfile,
   zuvyMentorSlotManagement,
   zuvyMentorSlotAvailability,
-  organizationsRelations,
+  zuvyOrganizations,
 } from '../../../../drizzle/schema';
 
-import { and, eq, sql } from 'drizzle-orm';
+import { and, eq, inArray, sql } from 'drizzle-orm';
 
 @Injectable()
 export class MentorPublicService {
@@ -25,6 +26,7 @@ export class MentorPublicService {
     expertise?: string,
     title?: string,
     search?: string,
+    organizationId?: number,
   ) {
     limit = Number(limit);
     offset = Number(offset);
@@ -34,16 +36,18 @@ export class MentorPublicService {
     // Always filter for instructors only
     filters.push(eq(zuvyUserRoles.name, 'instructor'));
 
+    if (organizationId !== undefined) {
+      filters.push(eq(zuvyMentorSlotManagement.organizationId, organizationId));
+    }
+
     if (expertise && expertise !== 'all') {
       filters.push(
-        sql`CAST(${zuvyMentorSlotManagement.expertise} AS TEXT) ILIKE ${'%' + expertise + '%'}`,
+        sql`CAST(${zuvyMentorProfile.expertise} AS TEXT) ILIKE ${'%' + expertise + '%'}`,
       );
     }
 
     if (title && title !== 'all') {
-      filters.push(
-        sql`${zuvyMentorSlotManagement.title} ILIKE ${'%' + title + '%'}`,
-      );
+      filters.push(sql`${zuvyMentorProfile.title} ILIKE ${'%' + title + '%'}`);
     }
 
     if (search) {
@@ -51,8 +55,8 @@ export class MentorPublicService {
         sql`(
         ${users.name} ILIKE ${'%' + search + '%'}
         OR ${users.email} ILIKE ${'%' + search + '%'}
-        OR ${zuvyMentorSlotManagement.title} ILIKE ${'%' + search + '%'}
-        OR CAST(${zuvyMentorSlotManagement.expertise} AS TEXT) ILIKE ${'%' + search + '%'}
+        OR ${zuvyMentorProfile.title} ILIKE ${'%' + search + '%'}
+        OR CAST(${zuvyMentorProfile.expertise} AS TEXT) ILIKE ${'%' + search + '%'}
       )`,
       );
     }
@@ -63,9 +67,11 @@ export class MentorPublicService {
         name: users.name,
         email: users.email,
         role: zuvyUserRoles.name,
-        bio: zuvyMentorSlotManagement.bio,
-        expertise: zuvyMentorSlotManagement.expertise,
-        title: zuvyMentorSlotManagement.title,
+        organizationId: zuvyMentorSlotManagement.organizationId,
+        orgName: zuvyOrganizations.displayName,
+        bio: zuvyMentorProfile.bio,
+        expertise: zuvyMentorProfile.expertise,
+        title: zuvyMentorProfile.title,
 
         availableSlots: sql<number>`
           COUNT(*) FILTER (
@@ -95,6 +101,15 @@ export class MentorPublicService {
         zuvyMentorSlotManagement,
         eq(zuvyMentorSlotManagement.mentorUserId, users.id),
       )
+      .innerJoin(
+        zuvyMentorProfile,
+        eq(zuvyMentorProfile.mentorUserId, users.id),
+      )
+
+      .innerJoin(
+        zuvyOrganizations,
+        eq(zuvyOrganizations.id, zuvyMentorSlotManagement.organizationId),
+      )
 
       // slots
       .leftJoin(
@@ -123,9 +138,11 @@ export class MentorPublicService {
         users.name,
         users.email,
         zuvyUserRoles.name,
-        zuvyMentorSlotManagement.bio,
-        zuvyMentorSlotManagement.expertise,
-        zuvyMentorSlotManagement.title,
+        zuvyMentorSlotManagement.organizationId,
+        zuvyOrganizations.displayName,
+        zuvyMentorProfile.bio,
+        zuvyMentorProfile.expertise,
+        zuvyMentorProfile.title,
       )
 
       .limit(limit)
@@ -160,12 +177,20 @@ export class MentorPublicService {
 
     const totalCount = await db
       .select({
-        count: sql<number>`count(distinct ${users.id})`,
+        count: sql<number>`count(distinct ${zuvyMentorSlotManagement.id})`,
       })
       .from(users)
       .innerJoin(
         zuvyMentorSlotManagement,
         eq(zuvyMentorSlotManagement.mentorUserId, users.id),
+      )
+      .innerJoin(
+        zuvyMentorProfile,
+        eq(zuvyMentorProfile.mentorUserId, users.id),
+      )
+      .innerJoin(
+        zuvyOrganizations,
+        eq(zuvyOrganizations.id, zuvyMentorSlotManagement.organizationId),
       )
       .leftJoin(
         zuvyUserRolesAssigned,
@@ -192,23 +217,30 @@ export class MentorPublicService {
      GET MENTOR PROFILE
   ========================================================= */
 
-  async getMentorProfile(mentorUserId: number) {
+  async getMentorProfile(mentorUserId: number, organizationId?: number) {
+    const filters = [eq(users.id, BigInt(mentorUserId))];
+
+    if (organizationId !== undefined) {
+      filters.push(eq(zuvyMentorSlotManagement.organizationId, organizationId));
+    }
+
     const result = await db
       .select({
         userId: users.id,
         name: users.name,
         email: users.email,
         role: zuvyUserRoles.name,
+        orgName: zuvyOrganizations.displayName,
 
         mentorProfileId: zuvyMentorSlotManagement.id,
         organizationId: zuvyMentorSlotManagement.organizationId,
         mentorType: zuvyMentorSlotManagement.mentorType,
         timezone: zuvyMentorSlotManagement.timezone,
 
-        bio: zuvyMentorSlotManagement.bio,
-        expertise: zuvyMentorSlotManagement.expertise,
-        title: zuvyMentorSlotManagement.title,
-        pastExperiences: zuvyMentorSlotManagement.pastExperiences,
+        bio: zuvyMentorProfile.bio,
+        expertise: zuvyMentorProfile.expertise,
+        title: zuvyMentorProfile.title,
+        pastExperiences: zuvyMentorProfile.pastExperiences,
 
         status: zuvyMentorSlotManagement.status,
         isVerified: zuvyMentorSlotManagement.isVerified,
@@ -223,6 +255,14 @@ export class MentorPublicService {
         zuvyMentorSlotManagement,
         eq(zuvyMentorSlotManagement.mentorUserId, users.id),
       )
+      .innerJoin(
+        zuvyMentorProfile,
+        eq(zuvyMentorProfile.mentorUserId, users.id),
+      )
+      .innerJoin(
+        zuvyOrganizations,
+        eq(zuvyOrganizations.id, zuvyMentorSlotManagement.organizationId),
+      )
 
       .leftJoin(
         zuvyUserRolesAssigned,
@@ -234,7 +274,7 @@ export class MentorPublicService {
         eq(zuvyUserRoles.id, zuvyUserRolesAssigned.roleId),
       )
 
-      .where(eq(users.id, BigInt(mentorUserId)))
+      .where(and(...filters))
       .limit(1);
 
     return result[0] ?? null;
@@ -244,28 +284,61 @@ export class MentorPublicService {
      GET AVAILABLE SLOTS
   ========================================================= */
 
-  async getAvailableSlots(userId: number) {
-    const [profile] = await db
-      .select()
-      .from(zuvyMentorSlotManagement)
-      .where(eq(zuvyMentorSlotManagement.mentorUserId, BigInt(userId)))
-      .limit(1);
+  async getAvailableSlots(userId: number, organizationId?: number) {
+    const filters = [eq(zuvyMentorSlotManagement.mentorUserId, BigInt(userId))];
 
-    if (!profile) {
+    if (organizationId !== undefined) {
+      filters.push(eq(zuvyMentorSlotManagement.organizationId, organizationId));
+    }
+
+    const profiles = await db
+      .select({
+        id: zuvyMentorSlotManagement.id,
+        organizationId: zuvyMentorSlotManagement.organizationId,
+        orgName: zuvyOrganizations.displayName,
+      })
+      .from(zuvyMentorSlotManagement)
+      .innerJoin(
+        zuvyOrganizations,
+        eq(zuvyOrganizations.id, zuvyMentorSlotManagement.organizationId),
+      )
+      .where(and(...filters))
+      .limit(50);
+
+    if (!profiles.length) {
       return [];
     }
 
-    return db
+    const profileIds = profiles.map((profile) => profile.id);
+    const orgMetaByProfileId = new Map(
+      profiles.map((profile) => [
+        profile.id,
+        {
+          organizationId: profile.organizationId,
+          orgName: profile.orgName,
+        },
+      ]),
+    );
+
+    const slots = await db
       .select()
       .from(zuvyMentorSlotAvailability)
       .where(
         and(
-          eq(zuvyMentorSlotAvailability.mentorSlotManagementId, profile.id),
+          inArray(
+            zuvyMentorSlotAvailability.mentorSlotManagementId,
+            profileIds,
+          ),
           eq(zuvyMentorSlotAvailability.status, 'available'),
           eq(zuvyMentorSlotAvailability.isPublic, true),
           sql`${zuvyMentorSlotAvailability.slotStartDateTime} > NOW()`,
           sql`${zuvyMentorSlotAvailability.currentBookedCount} < ${zuvyMentorSlotAvailability.maxCapacity}`,
         ),
       );
+
+    return slots.map((slot) => ({
+      ...slot,
+      ...orgMetaByProfileId.get(slot.mentorSlotManagementId),
+    }));
   }
 }

--- a/src/controller/mentor-slot/student-mentor-slot.controller.ts
+++ b/src/controller/mentor-slot/student-mentor-slot.controller.ts
@@ -39,7 +39,7 @@ export class StudentMentorSlotController {
 
   @Get('mentors')
   @ApiOperation({ summary: 'Search mentors available to students' })
-  async getMentors(@Req() req: any, @Query() query: MentorSearchDto) {
+  async getMentors(@Query() query: MentorSearchDto) {
     return this.mentorPublicService.getAllMentors(
       query.limit,
       query.offset,
@@ -47,19 +47,42 @@ export class StudentMentorSlotController {
       query.expertise,
       query.title,
       query.search,
+      query.organizationId ? Number(query.organizationId) : undefined,
     );
   }
 
   @Get('mentors/:mentorUserId')
   @ApiOperation({ summary: 'Get a mentor profile for students' })
-  getMentorProfile(@Param('mentorUserId') mentorUserId: number) {
-    return this.mentorPublicService.getMentorProfile(mentorUserId);
+  @ApiQuery({
+    name: 'organizationId',
+    required: false,
+    type: Number,
+  })
+  getMentorProfile(
+    @Param('mentorUserId') mentorUserId: number,
+    @Query('organizationId') organizationId?: number,
+  ) {
+    return this.mentorPublicService.getMentorProfile(
+      mentorUserId,
+      organizationId ? Number(organizationId) : undefined,
+    );
   }
 
   @Get('mentors/:mentorId/availability')
   @ApiOperation({ summary: 'Get available slots for a mentor' })
-  getAvailableSlots(@Param('mentorId', ParseIntPipe) mentorId: number) {
-    return this.mentorPublicService.getAvailableSlots(mentorId);
+  @ApiQuery({
+    name: 'organizationId',
+    required: false,
+    type: Number,
+  })
+  getAvailableSlots(
+    @Param('mentorId', ParseIntPipe) mentorId: number,
+    @Query('organizationId') organizationId?: number,
+  ) {
+    return this.mentorPublicService.getAvailableSlots(
+      mentorId,
+      organizationId ? Number(organizationId) : undefined,
+    );
   }
 
   @Post('mentor-slots/book')

--- a/src/controller/notification/notification.controller.ts
+++ b/src/controller/notification/notification.controller.ts
@@ -26,6 +26,7 @@ export class NotificationController {
   async getMyNotifications(@Req() req) {
     return this.notificationService.getUserNotifications(
       BigInt(req.user[0].id),
+      req.user[0].orgId ? Number(req.user[0].orgId) : undefined,
     );
   }
 

--- a/src/controller/notification/notification.service.ts
+++ b/src/controller/notification/notification.service.ts
@@ -1,7 +1,10 @@
 import { Injectable } from '@nestjs/common';
 import { db } from '../../db';
-import { zuvyNotifications } from '../../../drizzle/schema';
-import { eq, desc, sql } from 'drizzle-orm';
+import {
+  zuvyMentorSlotBooking,
+  zuvyNotifications,
+} from '../../../drizzle/schema';
+import { and, desc, eq, sql } from 'drizzle-orm';
 
 @Injectable()
 export class NotificationService {
@@ -31,11 +34,24 @@ export class NotificationService {
       .where(eq(zuvyNotifications.id, notificationId));
   }
 
-  async getUserNotifications(userId: bigint) {
+  async getUserNotifications(userId: bigint, organizationId?: number) {
+    const filters = [eq(zuvyNotifications.userId, userId)];
+
+    if (organizationId !== undefined) {
+      filters.push(sql`(
+        ${zuvyNotifications.referenceType} IS DISTINCT FROM 'booking'
+        OR ${zuvyNotifications.referenceId} IN (
+          SELECT ${zuvyMentorSlotBooking.id}
+          FROM ${zuvyMentorSlotBooking}
+          WHERE ${zuvyMentorSlotBooking.organizationId} = ${organizationId}
+        )
+      )`);
+    }
+
     const notifications = await db
       .select()
       .from(zuvyNotifications)
-      .where(eq(zuvyNotifications.userId, userId))
+      .where(and(...filters))
       .orderBy(desc(zuvyNotifications.createdAt));
 
     const unreadResult = await db
@@ -45,7 +61,7 @@ export class NotificationService {
       `,
       })
       .from(zuvyNotifications)
-      .where(eq(zuvyNotifications.userId, userId));
+      .where(and(...filters));
 
     return {
       unreadCount: Number(unreadResult[0].unread),

--- a/src/controller/progress/tracking.controller.ts
+++ b/src/controller/progress/tracking.controller.ts
@@ -185,11 +185,13 @@ export class TrackingController {
           err.statusCode,
         ).send(res);
       }
-      return new SuccessResponse(
-        success.message,
-        success.statusCode,
-        success.data,
-      ).send(res);
+      return res.status(success.statusCode).json({
+        message: success.message,
+        code: success.statusCode,
+        isSuccess: true,
+        mentorshipEnabled: success.mentorshipEnabled ?? false,
+        data: success.data,
+      });
     } catch (error) {
       return ErrorResponse.BadRequestException(error.message).send(res);
     }
@@ -247,11 +249,13 @@ export class TrackingController {
           err.statusCode,
         ).send(res);
       }
-      return new SuccessResponse(
-        success.message,
-        success.statusCode,
-        success.data,
-      ).send(res);
+      return res.status(success.statusCode).json({
+        message: success.message,
+        code: success.statusCode,
+        isSuccess: true,
+        mentorshipEnabled: success.mentorshipEnabled ?? false,
+        data: success.data,
+      });
     } catch (error) {
       return ErrorResponse.BadRequestException(error.message).send(res);
     }
@@ -363,11 +367,13 @@ export class TrackingController {
           err.statusCode,
         ).send(res);
       }
-      return new SuccessResponse(
-        success.message,
-        success.statusCode,
-        success.data,
-      ).send(res);
+      return res.status(success.statusCode).json({
+        message: success.message,
+        code: success.statusCode,
+        isSuccess: true,
+        mentorshipEnabled: success.mentorshipEnabled ?? false,
+        data: success.data,
+      });
     } catch (error) {
       return ErrorResponse.BadRequestException(error.message).send(res);
     }

--- a/src/controller/progress/tracking.service.ts
+++ b/src/controller/progress/tracking.service.ts
@@ -1821,24 +1821,6 @@ export class TrackingService {
     bootcampId: number,
   ): Promise<any> {
     try {
-      // 1. Load modules in order (removed early bootcamp completion check)
-      const modules = await db
-        .select()
-        .from(zuvyCourseModules)
-        .where(eq(zuvyCourseModules.bootcampId, bootcampId))
-        .orderBy(zuvyCourseModules.order);
-
-      if (!modules.length) {
-        return [
-          null,
-          {
-            message: 'No modules found for this bootcamp',
-            statusCode: STATUS_CODES.OK,
-            data: [],
-          },
-        ];
-      }
-
       const bootcamp = await db
         .select()
         .from(zuvyBootcamps)
@@ -1852,6 +1834,25 @@ export class TrackingService {
       const mentorshipEnabled = bootcampType.length
         ? bootcampType[0].mentorshipEnabled
         : false;
+
+      // 1. Load modules in order (removed early bootcamp completion check)
+      const modules = await db
+        .select()
+        .from(zuvyCourseModules)
+        .where(eq(zuvyCourseModules.bootcampId, bootcampId))
+        .orderBy(zuvyCourseModules.order);
+
+      if (!modules.length) {
+        return [
+          null,
+          {
+            message: 'No modules found for this bootcamp',
+            statusCode: STATUS_CODES.OK,
+            mentorshipEnabled,
+            data: [],
+          },
+        ];
+      }
 
       // 2. Fetch all tracking data
       const moduleIds = modules.map((m) => m.id);
@@ -2064,6 +2065,7 @@ export class TrackingService {
             {
               message: 'You have completed this course. Well done!!',
               statusCode: STATUS_CODES.OK,
+              mentorshipEnabled,
               data: [],
             },
           ];
@@ -2074,6 +2076,7 @@ export class TrackingService {
             {
               message: 'No available content found',
               statusCode: STATUS_CODES.OK,
+              mentorshipEnabled,
               data: [],
             },
           ];
@@ -2099,7 +2102,6 @@ export class TrackingService {
                 typeId: 2,
                 bootcampId: currentModule.bootcampId,
                 bootcampName,
-                mentorshipEnabled,
                 newProject: proj.length ? proj[0] : null,
               },
             },
@@ -2139,6 +2141,7 @@ export class TrackingService {
                 {
                   message: 'Your latest updated course',
                   statusCode: STATUS_CODES.OK,
+                  mentorshipEnabled,
                   data: {
                     moduleId: module.id,
                     moduleName: module.name,
@@ -2175,6 +2178,7 @@ export class TrackingService {
             {
               message: 'No available content found in any module',
               statusCode: STATUS_CODES.OK,
+              mentorshipEnabled,
               data: [],
             },
           ];
@@ -2316,7 +2320,6 @@ export class TrackingService {
               typeId: 1,
               bootcampId: currentModule.bootcampId,
               bootcampName,
-              mentorshipEnabled,
               newChapter: nextChapter,
             },
           },
@@ -2329,6 +2332,7 @@ export class TrackingService {
         {
           message: 'You have completed this course. Well done!!',
           statusCode: STATUS_CODES.OK,
+          mentorshipEnabled,
           data: [],
         },
       ];


### PR DESCRIPTION
This PR cleans up the mentorship backend so it matches the actual product rules more closely:

- instructors can belong to multiple orgs
- the mentor profile should be shared across orgs
- slots, sessions, metrics, and mentor-side visibility must stay org-specific
- student/public mentor discovery should include org information
- slot creation should depend on mentorship eligibility in the active org, not on a manually filled single bootcampId
- student course-open flow should always receive mentorshipEnabled at top level, even when course content is empty
