### PR TITLE
feat(mentor): integrate dynamic Zoom license allocation

### DIFF
--- a/drizzle/migrations/0037_extend_license_assignments_for_mentor_slots.sql
+++ b/drizzle/migrations/0037_extend_license_assignments_for_mentor_slots.sql
@@ -32,3 +32,33 @@ CREATE INDEX IF NOT EXISTS "idx_license_assignments_source_type"
 
 CREATE INDEX IF NOT EXISTS "idx_license_assignments_time_window"
   ON "main"."license_assignments" ("start_time", "end_time");
+
+ALTER TABLE "main"."zuvy_mentor_session_recordings"
+  ADD COLUMN IF NOT EXISTS "zoom_recording_manifest" jsonb,
+  ADD COLUMN IF NOT EXISTS "local_segment_paths" jsonb,
+  ADD COLUMN IF NOT EXISTS "merged_file_path" text,
+  ADD COLUMN IF NOT EXISTS "metadata_verified" boolean DEFAULT false,
+  ADD COLUMN IF NOT EXISTS "segments_count" integer DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS "live_checked_at" timestamp with time zone,
+  ADD COLUMN IF NOT EXISTS "recording_start" timestamp with time zone,
+  ADD COLUMN IF NOT EXISTS "recording_end" timestamp with time zone,
+  ADD COLUMN IF NOT EXISTS "is_final_merged" boolean DEFAULT false;
+
+UPDATE "main"."zuvy_mentor_session_recordings"
+SET
+  "status" = 'DISCOVERED',
+  "retry_count" = 0,
+  "next_retry_at" = NULL,
+  "last_error" = NULL,
+  "updated_at" = NOW()
+WHERE "status" = 'PERMANENT_FAILED'
+  AND (
+    "last_error" ILIKE '%merged_file_path%'
+    OR "last_error" ILIKE '%zoom_recording_manifest%'
+    OR "last_error" ILIKE '%local_segment_paths%'
+    OR "last_error" ILIKE '%metadata_verified%'
+    OR "last_error" ILIKE '%segments_count%'
+    OR "last_error" ILIKE '%recording_start%'
+    OR "last_error" ILIKE '%recording_end%'
+    OR "last_error" ILIKE '%is_final_merged%'
+  );

--- a/drizzle/migrations/0037_extend_license_assignments_for_mentor_slots.sql
+++ b/drizzle/migrations/0037_extend_license_assignments_for_mentor_slots.sql
@@ -1,0 +1,34 @@
+ALTER TABLE "main"."license_assignments"
+  ADD COLUMN IF NOT EXISTS "mentor_slot_availability_id" integer,
+  ADD COLUMN IF NOT EXISTS "source_type" varchar(50) NOT NULL DEFAULT 'class_session';
+
+ALTER TABLE "main"."license_assignments"
+  ALTER COLUMN "session_id" DROP NOT NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'license_assignments_mentor_slot_availability_id_fkey'
+  ) THEN
+    ALTER TABLE "main"."license_assignments"
+      ADD CONSTRAINT "license_assignments_mentor_slot_availability_id_fkey"
+      FOREIGN KEY ("mentor_slot_availability_id")
+      REFERENCES "main"."zuvy_mentor_slot_availability"("id")
+      ON DELETE CASCADE;
+  END IF;
+END $$;
+
+UPDATE "main"."license_assignments"
+SET "source_type" = 'class_session'
+WHERE "source_type" IS NULL;
+
+CREATE INDEX IF NOT EXISTS "idx_license_assignments_mentor_slot"
+  ON "main"."license_assignments" ("mentor_slot_availability_id");
+
+CREATE INDEX IF NOT EXISTS "idx_license_assignments_source_type"
+  ON "main"."license_assignments" ("source_type");
+
+CREATE INDEX IF NOT EXISTS "idx_license_assignments_time_window"
+  ON "main"."license_assignments" ("start_time", "end_time");

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -4561,6 +4561,22 @@ export const zuvyMentorSessionRecordings = main.table(
     zoomMeetingUuid: text('zoom_meeting_uuid').default(null),
     zoomRecordingId: text('zoom_recording_id'),
 
+    // stores ALL MP4 segments from Zoom
+    zoomRecordingManifest: jsonb('zoom_recording_manifest'),
+    // stores local temp paths before merge
+    localSegmentPaths: jsonb('local_segment_paths'),
+    // final merged file path
+    mergedFilePath: text('merged_file_path'),
+    // metadata verification flag
+    metadataVerified: boolean('metadata_verified').default(false),
+    // number of segments detected
+    segmentsCount: integer('segments_count').default(0),
+
+    liveCheckedAt: timestamp('live_checked_at', {
+      withTimezone: true,
+      mode: 'string',
+    }),
+
     status: varchar('status', { length: 32 })
       .notNull()
       .default('DISCOVERED'),
@@ -4574,6 +4590,17 @@ export const zuvyMentorSessionRecordings = main.table(
 
     driveFileId: text('drive_file_id'),
     driveLink: text('drive_link'),
+
+    recordingStart: timestamp('recording_start', {
+      withTimezone: true,
+      mode: 'string',
+    }),
+    recordingEnd: timestamp('recording_end', {
+      withTimezone: true,
+      mode: 'string',
+    }),
+
+    isFinalMerged: boolean('is_final_merged').default(false),
 
     createdAt: timestamp('created_at', {
       withTimezone: true,

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -3991,9 +3991,14 @@ export const licenseAssignments = main.table('license_assignments', {
   instructorId: bigint('instructor_id', { mode: 'number' })
     .references(() => users.id)
     .notNull(),
-  sessionId: integer('session_id')
-    .references(() => zuvySessions.id)
-    .notNull(),
+  sessionId: integer('session_id').references(() => zuvySessions.id),
+  mentorSlotAvailabilityId: integer('mentor_slot_availability_id').references(
+    () => zuvyMentorSlotAvailability.id,
+    { onDelete: 'cascade' },
+  ),
+  sourceType: varchar('source_type', { length: 50 })
+    .notNull()
+    .default('class_session'),
   startTime: timestamp('start_time', {
     withTimezone: true,
     mode: 'date',
@@ -5096,5 +5101,4 @@ export const zuvyLearnerLeaderboardRelations = relations(zuvyLearnerLeaderboard,
     references: [zuvyBootcamps.id],
   }),
 }));
-
 

--- a/src/common/constants/zoom-license.constants.ts
+++ b/src/common/constants/zoom-license.constants.ts
@@ -1,6 +1,6 @@
 import { sql } from 'drizzle-orm';
 
-const DEFAULT_ZOOM_LICENSE_COOLDOWN_MINUTES = 2; //60
+const DEFAULT_ZOOM_LICENSE_COOLDOWN_MINUTES = 60; //60
 
 const parsedCooldownMinutes = Number(
   process.env.ZOOM_LICENSE_COOLDOWN_MINUTES ||

--- a/src/common/constants/zoom-license.constants.ts
+++ b/src/common/constants/zoom-license.constants.ts
@@ -1,6 +1,6 @@
 import { sql } from 'drizzle-orm';
 
-const DEFAULT_ZOOM_LICENSE_COOLDOWN_MINUTES = 60; //60
+const DEFAULT_ZOOM_LICENSE_COOLDOWN_MINUTES = 2; //60
 
 const parsedCooldownMinutes = Number(
   process.env.ZOOM_LICENSE_COOLDOWN_MINUTES ||

--- a/src/controller/classes/classes.service.ts
+++ b/src/controller/classes/classes.service.ts
@@ -63,6 +63,16 @@ export class ClassesService {
     );
   }
 
+  private blockingZoomAssignmentCondition() {
+    return or(
+      and(
+        eq(licenseAssignments.sourceType, 'class_session'),
+        this.blockingZoomSessionCondition(),
+      ),
+      eq(licenseAssignments.sourceType, 'mentor_slot'),
+    );
+  }
+
   private async isInstructorFreeForTimeRange(
     email: string,
     startTime: Date,
@@ -72,14 +82,11 @@ export class ClassesService {
     const overlapping = await db
       .select({ count: sql<number>`count(*)` })
       .from(licenseAssignments)
-      .innerJoin(
-        zuvySessions,
-        eq(licenseAssignments.sessionId, zuvySessions.id),
-      )
+      .leftJoin(zuvySessions, eq(licenseAssignments.sessionId, zuvySessions.id))
       .innerJoin(users, eq(licenseAssignments.instructorId, users.id))
       .where(
         and(
-          this.blockingZoomSessionCondition(),
+          this.blockingZoomAssignmentCondition(),
           eq(users.email, email),
           sql`${licenseAssignments.startTime} < ${endTime}`,
           sql`${licenseAssignments.endTime} + ${buildZoomLicenseCooldownIntervalSql()} > ${bufferedStartTime}`,
@@ -1563,14 +1570,14 @@ export class ClassesService {
             const overlappingAssignments = await trx
               .select({ count: sql<number>`count(*)` })
               .from(licenseAssignments)
-              .innerJoin(
+              .leftJoin(
                 zuvySessions,
                 eq(licenseAssignments.sessionId, zuvySessions.id),
               )
               .innerJoin(users, eq(licenseAssignments.instructorId, users.id))
               .where(
                 and(
-                  this.blockingZoomSessionCondition(),
+                  this.blockingZoomAssignmentCondition(),
                   sql`${licenseAssignments.startTime} < ${new Date(original.endTime)}`,
                   sql`${licenseAssignments.endTime} + ${buildZoomLicenseCooldownIntervalSql()} > ${new Date(original.startTime)}`,
                   usingProtectedSeat

--- a/src/controller/mentor-slot/mentor-slot.module.ts
+++ b/src/controller/mentor-slot/mentor-slot.module.ts
@@ -15,6 +15,7 @@ import { InstructorMentorSlotController } from './instructor-mentor-slot.control
 import { GoogleModule } from 'src/integrations/google/google.module';
 import { NewNotificationModule } from '../notification/notification.module';
 import { ZoomModule } from 'src/services/zoom/zoom.module';
+import { ZoomLicenseModule } from '../zoom-license/zoom-license.module';
 import { NotificationModule } from 'src/notification/notification.module';
 import { TrackinglogModule } from 'src/trackinglog/trackinglog.module';
 import { RbacModule } from '../../rbac/rbac.module';
@@ -24,6 +25,7 @@ import { RbacModule } from '../../rbac/rbac.module';
     GoogleModule,
     NewNotificationModule,
     ZoomModule,
+    ZoomLicenseModule,
     NotificationModule,
     TrackinglogModule,
     RbacModule,

--- a/src/controller/mentor-slot/mentor-slot.service.ts
+++ b/src/controller/mentor-slot/mentor-slot.service.ts
@@ -21,6 +21,7 @@ import {
   zuvyOrganizations,
   users,
   zuvyStudentBookingMetrics,
+  licenseAssignments,
 } from '../../../drizzle/schema';
 
 import {
@@ -42,6 +43,7 @@ import { NotificationService } from '../notification/notification.service';
 import { NotificationType } from '../notification/notification.types';
 import { ZoomService } from 'src/services/zoom/zoom.service';
 import { NotificationEmailService } from 'src/notification/email/email.service';
+import { ZoomLicenseService } from '../zoom-license/zoom-license.service';
 
 @Injectable()
 export class MentorSlotService {
@@ -50,6 +52,7 @@ export class MentorSlotService {
     private readonly notificationService: NotificationService,
     private readonly zoomService: ZoomService,
     private readonly emailService: NotificationEmailService,
+    private readonly zoomLicenseService: ZoomLicenseService,
   ) {}
 
   private mapMeetingLink(booking: any, userId: bigint) {
@@ -57,6 +60,10 @@ export class MentorSlotService {
       return booking.zoomStartUrl;
     }
     return booking.meetingLink;
+  }
+
+  private async syncZoomLicenseState() {
+    await this.zoomLicenseService.syncLicensedUsersFromZoom();
   }
 
   private async resolveInstructorOrganization(
@@ -365,6 +372,94 @@ export class MentorSlotService {
     return true;
   }
 
+  private async ensureMentorZoomAccountActive(
+    userId: number,
+    organizationId?: number,
+  ) {
+    const mentorProfile = await this.getOrCreateMentorProfile(
+      userId,
+      organizationId,
+    );
+
+    const [userRow] = await db
+      .select({ email: users.email })
+      .from(users)
+      .where(eq(users.id, BigInt(userId)))
+      .limit(1);
+
+    if (!userRow?.email) {
+      throw new NotFoundException('Mentor user not found');
+    }
+
+    const zoomResponse = await this.zoomService.getUser(userRow.email);
+
+    if (!zoomResponse.success || zoomResponse.data?.status !== 'active') {
+      await db
+        .update(zuvyMentorSlotManagement)
+        .set({
+          isVerified: false,
+          updatedAt: new Date(),
+        } as Partial<typeof zuvyMentorSlotManagement.$inferInsert>)
+        .where(eq(zuvyMentorSlotManagement.id, mentorProfile.id));
+
+      throw new BadRequestException(
+        'Mentor Zoom account is disconnected or inactive. Please reconnect Zoom before creating mentor slots.',
+      );
+    }
+
+    await db
+      .update(zuvyMentorSlotManagement)
+      .set({
+        isVerified: true,
+        updatedAt: new Date(),
+      } as Partial<typeof zuvyMentorSlotManagement.$inferInsert>)
+      .where(eq(zuvyMentorSlotManagement.id, mentorProfile.id));
+
+    return {
+      email: userRow.email,
+      zoomUser: zoomResponse.data,
+    };
+  }
+
+  private async ensureMentorSlotLicenseAssignment(
+    trx: any,
+    slot: any,
+    mentorProfile: any,
+  ) {
+    const [existingAssignment] = await trx
+      .select({ id: licenseAssignments.id })
+      .from(licenseAssignments)
+      .where(
+        and(
+          eq(licenseAssignments.sourceType, 'mentor_slot'),
+          eq(licenseAssignments.mentorSlotAvailabilityId, slot.id),
+        ),
+      )
+      .limit(1);
+
+    if (existingAssignment) {
+      return;
+    }
+
+    const start = new Date(slot.slotStartDateTime);
+    const end = new Date(slot.slotEndDateTime);
+
+    const licenseId = await this.zoomLicenseService.assignLicense(trx, {
+      instructorId: Number(mentorProfile.mentorUserId),
+      startTime: start,
+      endTime: end,
+    });
+
+    await this.zoomLicenseService.createLicenseAssignment(trx, {
+      licenseId,
+      instructorId: Number(mentorProfile.mentorUserId),
+      mentorSlotAvailabilityId: slot.id,
+      sourceType: 'mentor_slot',
+      startTime: start,
+      endTime: end,
+    });
+  }
+
   private async validateMentorProfileComplete(
     userId: number,
     organizationId?: number,
@@ -658,6 +753,7 @@ export class MentorSlotService {
   async bookSlot(studentId: number, slotId: number) {
     await this.ensureMentorshipEnabled(BigInt(studentId));
     await this.validateLearnerBookingEligibility(BigInt(studentId));
+    await this.syncZoomLicenseState();
 
     return db.transaction(async (trx) => {
       /* ========================================
@@ -763,6 +859,8 @@ export class MentorSlotService {
         throw new BadRequestException('You already booked this slot.');
       }
 
+      await this.ensureMentorSlotLicenseAssignment(trx, slot, mentorProfile);
+
       /* ========================================
          UPDATE SLOT CAPACITY (NO SQL)
       ======================================== */
@@ -863,6 +961,10 @@ export class MentorSlotService {
       const mentorEmail = mentorUser?.email;
       const studentEmail = studentUser?.email;
 
+      if (!mentorEmail) {
+        throw new BadRequestException('Mentor email not found.');
+      }
+
       const refreshToken = mentorProfile.googleRefreshToken;
 
       const slotStartDateTime = new Date(slot.slotStartDateTime);
@@ -882,6 +984,12 @@ export class MentorSlotService {
 
       /* Create Zoom Meeting */
       try {
+        await this.zoomLicenseService.ensureHostLicensedForWindow(
+          mentorEmail,
+          slotStartDateTime,
+          slotEndDateTime,
+        );
+
         const zoomMeetingData = {
           topic: `Mentorship Session: ${mentorEmail} & ${studentEmail}`,
           type: 2, // Scheduled meeting
@@ -936,6 +1044,10 @@ export class MentorSlotService {
         console.error('Zoom meeting creation failed:', error.message);
 
         const errMsg = error?.message || '';
+
+        if (error instanceof BadRequestException) {
+          throw error;
+        }
 
         /* ========================================
            HANDLE ZOOM USER NOT FOUND / NOT LICENSED
@@ -1094,6 +1206,8 @@ export class MentorSlotService {
     cancelledBy: 'mentor' | 'student',
     actorUserId?: number,
   ) {
+    await this.syncZoomLicenseState();
+
     if (!reason || reason.length < 10) {
       throw new BadRequestException(
         'Cancellation reason must be at least 10 characters.',
@@ -1274,6 +1388,8 @@ export class MentorSlotService {
     reason: string,
     studentUserId?: number,
   ) {
+    await this.syncZoomLicenseState();
+
     if (!reason || reason.length < 10) {
       throw new BadRequestException(
         'Reschedule reason must be at least 10 characters.',
@@ -1403,6 +1519,8 @@ export class MentorSlotService {
   }
 
   async getRescheduleSlotsForBooking(studentUserId: number, bookingId: number) {
+    await this.syncZoomLicenseState();
+
     const [booking] = await db
       .select()
       .from(zuvyMentorSlotBooking)
@@ -1736,6 +1854,7 @@ export class MentorSlotService {
   ========================================================================== */
 
   async removeSlot(userId: number, slotId: number, organizationId?: number) {
+    await this.syncZoomLicenseState();
     await this.ensureUserIsMentor(userId);
 
     const mentorProfile = await this.getOrCreateMentorProfile(
@@ -1782,10 +1901,14 @@ export class MentorSlotService {
     // 12-hour deletion notice is temporarily disabled for short-notice slots.
     // this.enforceMinimumNotice(slot.slotStartDateTime);
 
-    const result = await db
-      .delete(zuvyMentorSlotAvailability)
-      .where(eq(zuvyMentorSlotAvailability.id, slotId))
-      .returning();
+    const result = await db.transaction(async (trx) => {
+      await this.zoomLicenseService.releaseMentorSlotAssignment(trx, slotId);
+
+      return trx
+        .delete(zuvyMentorSlotAvailability)
+        .where(eq(zuvyMentorSlotAvailability.id, slotId))
+        .returning();
+    });
 
     if (!result.length) {
       throw new NotFoundException('Slot not found or already deleted');
@@ -1801,6 +1924,8 @@ export class MentorSlotService {
     mentorUserId?: number,
     organizationId?: number,
   ) {
+    await this.syncZoomLicenseState();
+
     if (mentorUserId) {
       await this.ensureMentorOwnsBooking(
         mentorUserId,
@@ -1831,6 +1956,8 @@ export class MentorSlotService {
       const [mentorProfile] = await trx
         .select({
           id: zuvyMentorSlotManagement.id,
+          mentorUserId: zuvyMentorSlotManagement.mentorUserId,
+          organizationId: zuvyMentorSlotManagement.organizationId,
           googleRefreshToken: zuvyMentorSlotManagement.googleRefreshToken,
         })
         .from(zuvyMentorSlotManagement)
@@ -1847,6 +1974,30 @@ export class MentorSlotService {
           'Mentor profile not found for the booking organization.',
         );
       }
+
+      const [proposedSlot] = await trx
+        .select()
+        .from(zuvyMentorSlotAvailability)
+        .where(
+          and(
+            eq(zuvyMentorSlotAvailability.id, booking.rescheduleProposedSlotId),
+            eq(
+              zuvyMentorSlotAvailability.mentorSlotManagementId,
+              mentorProfile.id,
+            ),
+          ),
+        )
+        .for('update');
+
+      if (!proposedSlot) {
+        throw new BadRequestException('Invalid proposed slot.');
+      }
+
+      await this.ensureMentorSlotLicenseAssignment(
+        trx,
+        proposedSlot,
+        mentorProfile,
+      );
 
       /* Atomic capacity check + increment */
 
@@ -1934,6 +2085,8 @@ export class MentorSlotService {
     mentorUserId?: number,
     organizationId?: number,
   ) {
+    await this.syncZoomLicenseState();
+
     if (mentorUserId) {
       await this.ensureMentorOwnsBooking(
         mentorUserId,
@@ -1976,10 +2129,11 @@ export class MentorSlotService {
   }
 
   async createSlot(userId: number, dto: any, organizationId?: number) {
+    await this.syncZoomLicenseState();
     await this.ensureUserIsMentor(userId);
     await this.validateMentorProfileComplete(userId, organizationId);
     await this.ensureMentorHasMentorshipEnabledBootcamp(userId, organizationId);
-    await this.ensureMentorZoomVerified(userId, organizationId);
+    await this.ensureMentorZoomAccountActive(userId, organizationId);
 
     const mentorProfile = await this.getOrCreateMentorProfile(
       userId,
@@ -2048,19 +2202,38 @@ export class MentorSlotService {
       );
     }
 
-    return db
-      .insert(zuvyMentorSlotAvailability)
-      .values({
-        mentorSlotManagementId: mentorProfile.id,
-        slotStartDateTime: start,
-        slotEndDateTime: end,
-        durationMinutes,
-        maxCapacity: dto.maxCapacity ?? 1,
-        topic: dto.topic ?? null,
-        status: 'available',
-        isPublic: true,
-      } as typeof zuvyMentorSlotAvailability.$inferInsert)
-      .returning();
+    return db.transaction(async (trx) => {
+      const licenseId = await this.zoomLicenseService.assignLicense(trx, {
+        instructorId: userId,
+        startTime: start,
+        endTime: end,
+      });
+
+      const createdSlots = await trx
+        .insert(zuvyMentorSlotAvailability)
+        .values({
+          mentorSlotManagementId: mentorProfile.id,
+          slotStartDateTime: start,
+          slotEndDateTime: end,
+          durationMinutes,
+          maxCapacity: dto.maxCapacity ?? 1,
+          topic: dto.topic ?? null,
+          status: 'available',
+          isPublic: true,
+        } as typeof zuvyMentorSlotAvailability.$inferInsert)
+        .returning();
+
+      await this.zoomLicenseService.createLicenseAssignment(trx, {
+        licenseId,
+        instructorId: userId,
+        mentorSlotAvailabilityId: createdSlots[0].id,
+        sourceType: 'mentor_slot',
+        startTime: start,
+        endTime: end,
+      });
+
+      return createdSlots;
+    });
   }
 
   async getMySlots(
@@ -2079,7 +2252,7 @@ export class MentorSlotService {
     if (!mentorProfile) {
       throw new NotFoundException('Mentor profile not found.');
     }
-    await this.ensureMentorZoomVerified(userId, organizationId);
+    await this.ensureMentorZoomAccountActive(userId, organizationId);
 
     const now = new Date();
 
@@ -2465,6 +2638,8 @@ export class MentorSlotService {
     leftAtStr: string,
     mentorUserId?: number,
   ) {
+    await this.syncZoomLicenseState();
+
     if (mentorUserId) {
       await this.ensureMentorOwnsBooking(mentorUserId, bookingId);
     }
@@ -2491,6 +2666,8 @@ export class MentorSlotService {
   }
 
   async completeSession(bookingId: number, mentorUserId?: number) {
+    await this.syncZoomLicenseState();
+
     if (mentorUserId) {
       await this.ensureMentorOwnsBooking(mentorUserId, bookingId);
     }

--- a/src/controller/mentor-slot/recurrence/mentor-recurrence.service.ts
+++ b/src/controller/mentor-slot/recurrence/mentor-recurrence.service.ts
@@ -11,9 +11,12 @@ import {
   zuvyMentorSlotManagement,
 } from '../../../../drizzle/schema';
 import { and, eq, sql } from 'drizzle-orm';
+import { ZoomLicenseService } from '../../zoom-license/zoom-license.service';
 
 @Injectable()
 export class MentorRecurrenceService {
+  constructor(private readonly zoomLicenseService: ZoomLicenseService) {}
+
   /* ==========================================================================
      GENERATE RECURRING SLOTS
   ========================================================================== */
@@ -40,17 +43,19 @@ export class MentorRecurrenceService {
 
     if (!recurrenceRule) throw new BadRequestException('RRULE is required');
 
+    await this.zoomLicenseService.syncLicensedUsersFromZoom();
+
+    const [mentorProfile] = await db
+      .select()
+      .from(zuvyMentorSlotManagement)
+      .where(eq(zuvyMentorSlotManagement.id, mentorSlotManagementId))
+      .limit(1);
+
+    if (!mentorProfile) {
+      throw new NotFoundException('Mentor profile not found.');
+    }
+
     if (mentorUserId) {
-      const [mentorProfile] = await db
-        .select()
-        .from(zuvyMentorSlotManagement)
-        .where(eq(zuvyMentorSlotManagement.id, mentorSlotManagementId))
-        .limit(1);
-
-      if (!mentorProfile) {
-        throw new NotFoundException('Mentor profile not found.');
-      }
-
       if (mentorProfile.mentorUserId !== BigInt(mentorUserId)) {
         throw new ForbiddenException('You do not own this mentor profile.');
       }
@@ -80,34 +85,69 @@ export class MentorRecurrenceService {
       return generatedSlots;
     }
 
-    /* Conflict Detection */
-    for (const slot of generatedSlots) {
-      const conflicts = await db
-        .select({ id: zuvyMentorSlotAvailability.id })
-        .from(zuvyMentorSlotAvailability)
-        .where(
-          and(
+    await db.transaction(async (trx) => {
+      /* Conflict Detection */
+      for (const slot of generatedSlots) {
+        const conflicts = await trx
+          .select({ id: zuvyMentorSlotAvailability.id })
+          .from(zuvyMentorSlotAvailability)
+          .innerJoin(
+            zuvyMentorSlotManagement,
             eq(
               zuvyMentorSlotAvailability.mentorSlotManagementId,
-              mentorSlotManagementId,
+              zuvyMentorSlotManagement.id,
             ),
-            sql`${zuvyMentorSlotAvailability.slotStartDateTime} < ${slot.slotEndDateTime}`,
-            sql`${zuvyMentorSlotAvailability.slotEndDateTime} > ${slot.slotStartDateTime}`,
-          ),
-        );
+          )
+          .where(
+            and(
+              eq(
+                zuvyMentorSlotManagement.mentorUserId,
+                mentorProfile.mentorUserId,
+              ),
+              sql`${zuvyMentorSlotAvailability.slotStartDateTime} < ${slot.slotEndDateTime}`,
+              sql`${zuvyMentorSlotAvailability.slotEndDateTime} > ${slot.slotStartDateTime}`,
+            ),
+          );
 
-      if (conflicts.length > 0) {
-        throw new BadRequestException(
-          'Recurring slot conflicts with existing availability.',
-        );
+        if (conflicts.length > 0) {
+          throw new BadRequestException(
+            'Recurring slot conflicts with existing mentor availability.',
+          );
+        }
       }
-    }
 
-    await db
-      .insert(zuvyMentorSlotAvailability)
-      .values(
-        generatedSlots as (typeof zuvyMentorSlotAvailability.$inferInsert)[],
-      );
+      const licenseIds: number[] = [];
+
+      for (const slot of generatedSlots) {
+        const licenseId = await this.zoomLicenseService.assignLicense(trx, {
+          instructorId: Number(mentorProfile.mentorUserId),
+          startTime: slot.slotStartDateTime,
+          endTime: slot.slotEndDateTime,
+        });
+
+        licenseIds.push(licenseId);
+      }
+
+      const createdSlots = await trx
+        .insert(zuvyMentorSlotAvailability)
+        .values(
+          generatedSlots as (typeof zuvyMentorSlotAvailability.$inferInsert)[],
+        )
+        .returning();
+
+      for (let index = 0; index < createdSlots.length; index += 1) {
+        const createdSlot = createdSlots[index];
+
+        await this.zoomLicenseService.createLicenseAssignment(trx, {
+          licenseId: licenseIds[index],
+          instructorId: Number(mentorProfile.mentorUserId),
+          mentorSlotAvailabilityId: createdSlot.id,
+          sourceType: 'mentor_slot',
+          startTime: new Date(createdSlot.slotStartDateTime),
+          endTime: new Date(createdSlot.slotEndDateTime),
+        });
+      }
+    });
 
     return { message: 'Recurring slots created successfully.' };
   }

--- a/src/controller/zoom-license/zoom-license.service.ts
+++ b/src/controller/zoom-license/zoom-license.service.ts
@@ -78,6 +78,16 @@ export class ZoomLicenseService {
     );
   }
 
+  private blockingAssignmentCondition() {
+    return or(
+      and(
+        eq(licenseAssignments.sourceType, 'class_session'),
+        this.blockingSessionCondition(),
+      ),
+      eq(licenseAssignments.sourceType, 'mentor_slot'),
+    );
+  }
+
   private getBufferedEndTime(date: Date) {
     return new Date(date.getTime() + this.licenseCooldownMs);
   }
@@ -207,6 +217,8 @@ export class ZoomLicenseService {
         instructorName: users.name,
         sessionId: zuvySessions.id,
         sessionTitle: zuvySessions.title,
+        mentorSlotAvailabilityId: licenseAssignments.mentorSlotAvailabilityId,
+        sourceType: licenseAssignments.sourceType,
         startTime: licenseAssignments.startTime,
         endTime: licenseAssignments.endTime,
       })
@@ -215,14 +227,11 @@ export class ZoomLicenseService {
         zuvyUserLicenses,
         eq(licenseAssignments.licenseId, zuvyUserLicenses.id),
       )
-      .innerJoin(
-        zuvySessions,
-        eq(licenseAssignments.sessionId, zuvySessions.id),
-      )
+      .leftJoin(zuvySessions, eq(licenseAssignments.sessionId, zuvySessions.id))
       .innerJoin(users, eq(licenseAssignments.instructorId, users.id))
       .where(
         and(
-          this.blockingSessionCondition(),
+          this.blockingAssignmentCondition(),
           lt(licenseAssignments.startTime, dto.endTime),
           sql`${licenseAssignments.endTime} + ${buildZoomLicenseCooldownIntervalSql()} > ${dto.startTime}`,
           this.buildInstructorPoolCondition(
@@ -253,7 +262,12 @@ export class ZoomLicenseService {
               ? 'self'
               : 'transfer';
 
-          return `${row.licenseEmail} (${row.licenseName || 'license'}) -> ${row.instructorEmail} (${row.instructorName || 'instructor'}) [${transferLabel}] | session ${row.sessionId}: "${row.sessionTitle}" | ${row.startTime.toISOString()} -> ${row.endTime.toISOString()}`;
+          const resourceLabel =
+            row.sourceType === 'mentor_slot'
+              ? `mentor slot ${row.mentorSlotAvailabilityId}`
+              : `session ${row.sessionId}: "${row.sessionTitle}"`;
+
+          return `${row.licenseEmail} (${row.licenseName || 'license'}) -> ${row.instructorEmail} (${row.instructorName || 'instructor'}) [${transferLabel}] | ${resourceLabel} | ${row.startTime.toISOString()} -> ${row.endTime.toISOString()}`;
         })
         .join('; ') || 'none';
 
@@ -286,14 +300,11 @@ export class ZoomLicenseService {
         endTime: licenseAssignments.endTime,
       })
       .from(licenseAssignments)
-      .innerJoin(
-        zuvySessions,
-        eq(licenseAssignments.sessionId, zuvySessions.id),
-      )
+      .leftJoin(zuvySessions, eq(licenseAssignments.sessionId, zuvySessions.id))
       .innerJoin(users, eq(licenseAssignments.instructorId, users.id))
       .where(
         and(
-          this.blockingSessionCondition(),
+          this.blockingAssignmentCondition(),
           this.buildInstructorPoolCondition(
             protectedEmailList,
             instructorEmail,
@@ -362,14 +373,11 @@ export class ZoomLicenseService {
     const overlappingCount = await trx
       .select({ count: sql<number>`count(*)` })
       .from(licenseAssignments)
-      .innerJoin(
-        zuvySessions,
-        eq(licenseAssignments.sessionId, zuvySessions.id),
-      )
+      .leftJoin(zuvySessions, eq(licenseAssignments.sessionId, zuvySessions.id))
       .innerJoin(users, eq(licenseAssignments.instructorId, users.id))
       .where(
         and(
-          this.blockingSessionCondition(),
+          this.blockingAssignmentCondition(),
           lt(licenseAssignments.startTime, dto.endTime),
           sql`${licenseAssignments.endTime} + ${buildZoomLicenseCooldownIntervalSql()} > ${dto.startTime}`,
           this.buildInstructorPoolCondition(
@@ -417,13 +425,13 @@ export class ZoomLicenseService {
             db
               .select({ one: sql`1` })
               .from(licenseAssignments)
-              .innerJoin(
+              .leftJoin(
                 zuvySessions,
                 eq(licenseAssignments.sessionId, zuvySessions.id),
               )
               .where(
                 and(
-                  this.blockingSessionCondition(),
+                  this.blockingAssignmentCondition(),
                   eq(licenseAssignments.licenseId, zuvyUserLicenses.id),
                   sql`${licenseAssignments.startTime} < ${dto.endTime}`,
                   sql`${licenseAssignments.endTime} + ${buildZoomLicenseCooldownIntervalSql()} > ${dto.startTime}`,
@@ -563,6 +571,15 @@ export class ZoomLicenseService {
     const instructorIsProtected = instructorEmail
       ? protectedEmails.has(instructorEmail)
       : false;
+    const transferablePoolCapacity = instructorIsProtected
+      ? 1
+      : await this.getTransferableLicensePoolCount(trx);
+
+    if (!instructorIsProtected && transferablePoolCapacity <= 0) {
+      throw new BadRequestException(
+        'No transferable Zoom Business licenses are available. All Business licenses are protected.',
+      );
+    }
 
     await this.logLicensePoolSnapshot(
       trx,
@@ -580,9 +597,7 @@ export class ZoomLicenseService {
     });
 
     if (availableLicenses.length === 0) {
-      const poolCapacity = instructorIsProtected
-        ? 1
-        : await this.getTransferableLicensePoolCount(trx);
+      let poolCapacity = transferablePoolCapacity;
       let totalCount = instructorIsProtected
         ? await this.getActiveLicensePoolCount(trx, {
             instructorEmail,
@@ -601,7 +616,14 @@ export class ZoomLicenseService {
           ? await this.getActiveLicensePoolCount(trx, {
               instructorEmail,
             })
-          : poolCapacity;
+          : await this.getTransferableLicensePoolCount(trx);
+        poolCapacity = instructorIsProtected ? 1 : Number(totalCount);
+
+        if (!instructorIsProtected && poolCapacity <= 0) {
+          throw new BadRequestException(
+            'No transferable Zoom Business licenses are available. All Business licenses are protected.',
+          );
+        }
       }
 
       if (availableLicenses.length > 0) {
@@ -670,14 +692,11 @@ export class ZoomLicenseService {
         email: users.email,
       })
       .from(licenseAssignments)
-      .innerJoin(
-        zuvySessions,
-        eq(licenseAssignments.sessionId, zuvySessions.id),
-      )
+      .leftJoin(zuvySessions, eq(licenseAssignments.sessionId, zuvySessions.id))
       .innerJoin(users, eq(licenseAssignments.instructorId, users.id))
       .where(
         and(
-          this.blockingSessionCondition(),
+          this.blockingAssignmentCondition(),
           lt(licenseAssignments.startTime, dto.endTime),
           sql`${licenseAssignments.endTime} + ${buildZoomLicenseCooldownIntervalSql()} > ${dto.startTime}`,
           this.buildInstructorPoolCondition(
@@ -709,6 +728,177 @@ export class ZoomLicenseService {
     return assignedLicenseId;
   }
 
+  private buildZoomScopeError(
+    action: 'list' | 'transfer',
+    sourceEmail?: string,
+    targetEmail?: string,
+  ) {
+    if (action === 'list') {
+      return 'Cannot inspect currently licensed Zoom users because the configured Zoom access token is missing the required admin read scope (user:read:list_users:admin). Please reconnect Zoom with admin permissions or update the OAuth app scopes.';
+    }
+
+    return `Cannot transfer the Zoom license from ${sourceEmail} to ${targetEmail} because the configured Zoom access token is missing the required admin scopes (user:update:user and user:update:user:admin). Please reconnect Zoom with admin permissions or update the OAuth app scopes.`;
+  }
+
+  private async isZoomEmailFreeForTimeRange(
+    email: string,
+    startTime: Date,
+    endTime: Date,
+  ) {
+    const overlapping = await db
+      .select({ count: sql<number>`count(*)` })
+      .from(licenseAssignments)
+      .leftJoin(zuvySessions, eq(licenseAssignments.sessionId, zuvySessions.id))
+      .innerJoin(users, eq(licenseAssignments.instructorId, users.id))
+      .where(
+        and(
+          this.blockingAssignmentCondition(),
+          eq(sql<string>`lower(${users.email})`, email.toLowerCase()),
+          sql`${licenseAssignments.startTime} < ${endTime}`,
+          sql`${licenseAssignments.endTime} + ${buildZoomLicenseCooldownIntervalSql()} > ${startTime}`,
+        ),
+      );
+
+    return Number(overlapping[0]?.count || 0) === 0;
+  }
+
+  private async findAvailableLicensedDonor(
+    instructorEmail: string,
+    startTime: Date,
+    endTime: Date,
+  ) {
+    const licensedUsers = await this.zoomService.listAuthorizedUsers({
+      status: 'active',
+      hostType: 'licensed',
+      page_size: 300,
+    });
+
+    if (!licensedUsers.success) {
+      if (
+        /does not contain scopes/i.test(licensedUsers.error || '') &&
+        /user:read:list_users:admin/i.test(licensedUsers.error || '')
+      ) {
+        throw new BadRequestException(this.buildZoomScopeError('list'));
+      }
+
+      throw new BadRequestException(
+        `Failed to inspect Zoom licensed users: ${licensedUsers.error || 'Unknown Zoom error'}`,
+      );
+    }
+
+    const protectedEmails = await this.getProtectedLicenseEmails();
+    const donors = (licensedUsers.data?.users || [])
+      .filter(
+        (user) =>
+          user.email?.trim().toLowerCase() !== instructorEmail.toLowerCase(),
+      )
+      .filter(
+        (user) => !protectedEmails.has(user.email?.trim().toLowerCase() || ''),
+      );
+
+    for (const donor of donors) {
+      const donorEmail = donor.email?.trim().toLowerCase();
+
+      if (
+        donorEmail &&
+        (await this.isZoomEmailFreeForTimeRange(donorEmail, startTime, endTime))
+      ) {
+        return donorEmail;
+      }
+    }
+
+    return null;
+  }
+
+  async ensureHostLicensedForWindow(
+    hostEmail: string,
+    startTime: Date,
+    endTime: Date,
+  ) {
+    let licenseResult = await this.zoomService.ensureLicensedUser(
+      hostEmail,
+      '',
+      '',
+    );
+
+    if (licenseResult.success && licenseResult.licensed) {
+      return;
+    }
+
+    const needsSeatTransfer =
+      licenseResult.step === 'license' ||
+      /license/i.test(licenseResult.error || '') ||
+      /maximum number of .* paying users/i.test(licenseResult.error || '');
+
+    const isZoomLicensePoolFull =
+      licenseResult.step === 'verify' &&
+      /currently basic/i.test(licenseResult.error || '');
+
+    if (!needsSeatTransfer && !isZoomLicensePoolFull) {
+      throw new BadRequestException(
+        `Failed to assign Zoom license to ${hostEmail}: ${licenseResult.error || 'Unknown Zoom licensing error'}`,
+      );
+    }
+
+    const donorEmail = await this.findAvailableLicensedDonor(
+      hostEmail,
+      startTime,
+      endTime,
+    );
+
+    if (!donorEmail) {
+      throw new BadRequestException(
+        `No free licensed Zoom user is available to transfer a seat to ${hostEmail} for this session time.`,
+      );
+    }
+
+    const downgradeResult = await this.zoomService.downgradeUser(donorEmail);
+
+    if (!downgradeResult.success) {
+      if (
+        /does not contain scopes/i.test(downgradeResult.error || '') &&
+        /user:update:user(?::admin)?/i.test(downgradeResult.error || '')
+      ) {
+        throw new BadRequestException(
+          this.buildZoomScopeError('transfer', donorEmail, hostEmail),
+        );
+      }
+
+      throw new BadRequestException(
+        `Failed to transfer Zoom license from ${donorEmail} to ${hostEmail}: ${downgradeResult.error}`,
+      );
+    }
+
+    licenseResult = await this.zoomService.ensureLicensedUser(
+      hostEmail,
+      '',
+      '',
+    );
+
+    if (licenseResult.success && licenseResult.licensed) {
+      this.logger.log(
+        `Transferred Zoom license from ${donorEmail} to ${hostEmail} for ${startTime.toISOString()} - ${endTime.toISOString()}.`,
+      );
+      return;
+    }
+
+    const rollbackResult = await this.zoomService.ensureLicensedUser(
+      donorEmail,
+      '',
+      '',
+    );
+
+    if (!rollbackResult.success || !rollbackResult.licensed) {
+      this.logger.error(
+        `Failed to restore Zoom license to donor ${donorEmail} after unsuccessful transfer to ${hostEmail}.`,
+      );
+    }
+
+    throw new BadRequestException(
+      `Failed to assign Zoom license to ${hostEmail}: ${licenseResult.error || 'Unknown Zoom licensing error'}`,
+    );
+  }
+
   /**
    * Internal method to finalize a license assignment record.
    * Should be called within a transaction after the session is saved.
@@ -718,18 +908,55 @@ export class ZoomLicenseService {
     dto: {
       licenseId: number;
       instructorId: number;
-      sessionId: number;
+      sessionId?: number;
+      mentorSlotAvailabilityId?: number;
+      sourceType?: 'class_session' | 'mentor_slot';
       startTime: Date;
       endTime: Date;
     },
   ) {
+    const sourceType =
+      dto.sourceType ??
+      (dto.mentorSlotAvailabilityId ? 'mentor_slot' : 'class_session');
+
+    if (sourceType === 'class_session' && !dto.sessionId) {
+      throw new BadRequestException(
+        'sessionId is required for class license assignment.',
+      );
+    }
+
+    if (sourceType === 'mentor_slot' && !dto.mentorSlotAvailabilityId) {
+      throw new BadRequestException(
+        'mentorSlotAvailabilityId is required for mentor slot license assignment.',
+      );
+    }
+
     await trx.insert(licenseAssignments).values({
       licenseId: dto.licenseId,
       instructorId: dto.instructorId,
-      sessionId: dto.sessionId,
+      sessionId: dto.sessionId ?? null,
+      mentorSlotAvailabilityId: dto.mentorSlotAvailabilityId ?? null,
+      sourceType,
       startTime: dto.startTime,
       endTime: dto.endTime,
     } as any);
+  }
+
+  async releaseMentorSlotAssignment(
+    trx: any,
+    mentorSlotAvailabilityId: number,
+  ) {
+    await trx
+      .delete(licenseAssignments)
+      .where(
+        and(
+          eq(licenseAssignments.sourceType, 'mentor_slot'),
+          eq(
+            licenseAssignments.mentorSlotAvailabilityId,
+            mentorSlotAvailabilityId,
+          ),
+        ),
+      );
   }
 
   async getInstructorLicenses(instructorId: number) {
@@ -753,6 +980,7 @@ export class ZoomLicenseService {
   }
 
   async getDashboard() {
+    const syncedLicensedUsers = await this.syncLicensedUsersFromZoom();
     const now = new Date();
 
     const totalLicenses = await this.getActiveLicensePoolCount();
@@ -760,13 +988,10 @@ export class ZoomLicenseService {
     const activeAssignments = await db
       .select({ count: sql<number>`count(*)` })
       .from(licenseAssignments)
-      .innerJoin(
-        zuvySessions,
-        eq(licenseAssignments.sessionId, zuvySessions.id),
-      )
+      .leftJoin(zuvySessions, eq(licenseAssignments.sessionId, zuvySessions.id))
       .where(
         and(
-          this.blockingSessionCondition(),
+          this.blockingAssignmentCondition(),
           lt(licenseAssignments.startTime, now),
           gt(licenseAssignments.endTime, now),
         ),
@@ -778,6 +1003,7 @@ export class ZoomLicenseService {
       totalLicenses,
       usedLicenses: usedCount,
       availableLicenses: totalLicenses - usedCount,
+      syncedLicensedUsers,
       timestamp: now,
     };
   }
@@ -824,6 +1050,8 @@ export class ZoomLicenseService {
           sessionId: zuvySessions.id,
           sessionTitle: zuvySessions.title,
           sessionStatus: zuvySessions.status,
+          mentorSlotAvailabilityId: licenseAssignments.mentorSlotAvailabilityId,
+          sourceType: licenseAssignments.sourceType,
         })
         .from(licenseAssignments)
         .innerJoin(
@@ -831,7 +1059,7 @@ export class ZoomLicenseService {
           eq(licenseAssignments.licenseId, zuvyUserLicenses.id),
         )
         .innerJoin(users, eq(licenseAssignments.instructorId, users.id))
-        .innerJoin(
+        .leftJoin(
           zuvySessions,
           eq(licenseAssignments.sessionId, zuvySessions.id),
         )
@@ -839,8 +1067,7 @@ export class ZoomLicenseService {
           and(
             lt(licenseAssignments.startTime, now),
             sql`${licenseAssignments.endTime} + ${buildZoomLicenseCooldownIntervalSql()} > ${now}`,
-            or(isNull(zuvySessions.status), ne(zuvySessions.status, 'merged')),
-            eq(zuvySessions.isZoomMeet, true),
+            this.blockingAssignmentCondition(),
           ),
         );
 
@@ -892,7 +1119,11 @@ export class ZoomLicenseService {
         assignments
           .map(
             (assignment) =>
-              `${assignment.licenseEmail} -> ${assignment.instructorEmail} (${assignment.instructorName || 'unknown'}) | session ${assignment.sessionId}: "${assignment.sessionTitle}" | ${assignment.startTime} -> ${assignment.endTime}`,
+              `${assignment.licenseEmail} -> ${assignment.instructorEmail} (${assignment.instructorName || 'unknown'}) | ${
+                assignment.sourceType === 'mentor_slot'
+                  ? `mentor slot ${assignment.mentorSlotAvailabilityId}`
+                  : `session ${assignment.sessionId}: "${assignment.sessionTitle}"`
+              } | ${assignment.startTime} -> ${assignment.endTime}`,
           )
           .join('\n') || 'none';
 

--- a/src/services/recording-worker/recording-worker.service.ts
+++ b/src/services/recording-worker/recording-worker.service.ts
@@ -266,14 +266,16 @@ export class RecordingWorkerService implements OnModuleInit {
       status = CASE
         WHEN status IN ('DISCOVERED', 'FAILED') THEN 'PROCESSING_METADATA'
         WHEN status = 'METADATA_READY' THEN 'PROCESSING_DOWNLOAD'
-        WHEN status = 'DOWNLOADING' THEN 'PROCESSING_UPLOAD'
+        WHEN status = 'DOWNLOADING' THEN 'DOWNLOADED'
+        WHEN status = 'DOWNLOADED' THEN 'MERGING'
+        WHEN status = 'MERGED' THEN 'PROCESSING_UPLOAD'
         ELSE status
       END,
       updated_at = NOW()
     WHERE id = (
       SELECT id
       FROM zuvy_mentor_session_recordings
-      WHERE status IN ('DISCOVERED', 'FAILED', 'METADATA_READY', 'DOWNLOADING')
+      WHERE status IN ('DISCOVERED', 'FAILED', 'METADATA_READY', 'DOWNLOADING', 'DOWNLOADED', 'MERGED')
         AND status NOT LIKE 'PROCESSING_%'
         AND status != 'PERMANENT_FAILED'
         AND retry_count < ${MAX_RETRIES}
@@ -516,6 +518,11 @@ export class RecordingWorkerService implements OnModuleInit {
         UPDATE zuvy_mentor_session_recordings
         SET
           zoom_recording_id = ${primaryMp4.id},
+          zoom_recording_manifest = ${JSON.stringify(manifest)},
+          segments_count = ${manifest.length},
+          metadata_verified = TRUE,
+          recording_start = ${manifest[0]?.recording_start || null},
+          recording_end = ${manifest[manifest.length - 1]?.recording_end || null},
           status = 'METADATA_READY'
         WHERE id = ${job.id}
       `);
@@ -597,7 +604,10 @@ export class RecordingWorkerService implements OnModuleInit {
       if (job.table === 'mentor') {
         await db.execute(sql`
           UPDATE zuvy_mentor_session_recordings
-          SET status = 'DOWNLOADING'
+          SET
+            local_segment_paths = ${JSON.stringify(downloadedPaths)},
+            segments_count = ${downloadedPaths.length},
+            status = 'DOWNLOADING'
           WHERE id = ${job.id}
         `);
       } else {
@@ -891,6 +901,7 @@ export class RecordingWorkerService implements OnModuleInit {
       UPDATE zuvy_mentor_session_recordings
       SET
         merged_file_path = ${mergedPath},
+        is_final_merged = TRUE,
         status = 'MERGED'
       WHERE id = ${job.id}
     `);


### PR DESCRIPTION

- Extend license assignments to support mentor slot reservations
- Reserve Zoom license capacity during mentor slot and recurrence creation
- Release mentor slot license assignments on empty slot deletion
- Add legacy assignment fallback for booking and reschedule flows
- Sync Zoom license state during mentor slot/session operations
- Enforce protected-license rules for non-protected Basic mentors
- Preserve actionable Zoom license errors during booking
- Include mentor slot assignments in shared class/mentor license usage checks
- Recording work flow updated