### PR TITLE
fix(attendance): consolidate /classes/attendance response, fix stale-record readiness gap and duplicate-row inconsistency

### DIFF
--- a/src/controller/classes/classes.service.ts
+++ b/src/controller/classes/classes.service.ts
@@ -21,6 +21,7 @@ import {
 import {
   eq,
   desc,
+  asc,
   and,
   or,
   ne,
@@ -50,6 +51,10 @@ import {
   resolveZoomAttendanceReadiness,
   resolveGoogleMeetAttendanceReadiness,
 } from 'src/services/attendance/attendance-readiness';
+import {
+  buildStudentAttendanceRecords,
+  StudentAttendanceRecord,
+} from 'src/services/attendance/attendance-record-merge';
 
 @Injectable()
 export class ClassesService {
@@ -4530,6 +4535,7 @@ export class ClassesService {
           status: zuvySessions.status,
           batchId: zuvySessions.batchId,
           secondBatchId: zuvySessions.secondBatchId,
+          bootcampId: zuvySessions.bootcampId,
           invitedStudents: zuvySessions.invitedStudents,
         })
         .from(zuvySessions)
@@ -4545,86 +4551,12 @@ export class ClassesService {
       const now = new Date();
       const sessionEndTime = new Date(session.endTime);
 
-      let readiness: {
-        ready: boolean;
-        state: string;
-        reason: string | null;
-      };
-
-      if (isZoomMeet) {
-        const latestJobRows = await db
-          .select({
-            status: zuvySessionAttendanceJobs.status,
-            lastError: zuvySessionAttendanceJobs.lastError,
-          })
-          .from(zuvySessionAttendanceJobs)
-          .where(eq(zuvySessionAttendanceJobs.sessionId, sessionId))
-          .orderBy(desc(zuvySessionAttendanceJobs.id))
-          .limit(1);
-
-        // Deliberately NOT gated on session.status — that column is only
-        // refreshed as a side effect of unrelated endpoints
-        // (updatingStatusOfClass) and can stay stale at 'ongoing' long
-        // after the class, and its attendance, are actually done. The job
-        // row's existence/status is authoritative and always current.
-        readiness = resolveZoomAttendanceReadiness(
-          now,
-          sessionEndTime,
-          latestJobRows[0] || null,
-        );
-      } else {
-        const existingRecord = await db
-          .select({ id: zuvyStudentAttendanceRecords.id })
-          .from(zuvyStudentAttendanceRecords)
-          .where(eq(zuvyStudentAttendanceRecords.sessionId, sessionId))
-          .limit(1);
-        const existingAggregate = session.meetingId
-          ? await db
-              .select({ id: zuvyStudentAttendance.id })
-              .from(zuvyStudentAttendance)
-              .where(eq(zuvyStudentAttendance.meetingId, session.meetingId))
-              .limit(1)
-          : [];
-
-        readiness = resolveGoogleMeetAttendanceReadiness(
-          now,
-          sessionEndTime,
-          existingRecord.length > 0 || existingAggregate.length > 0,
-        );
-      }
-
-      const emptyResult = {
-        sessionId: session.id,
-        sessionStatus: session.status,
-        isZoomMeet,
-        ...readiness,
-        totalStudents: 0,
-        presentCount: 0,
-        absentCount: 0,
-        attendancePercentage: 0,
-        records: [] as Array<{
-          userId: number;
-          name: string | null;
-          email: string | null;
-          status: string;
-          duration: number;
-        }>,
-      };
-
-      if (!readiness.ready) {
-        return [
-          null,
-          {
-            success: true,
-            data: emptyResult,
-            message: 'Attendance not ready yet',
-          },
-        ];
-      }
-
-      // Resolve the invited-student roster the same way meetingAttendanceAnalytics
-      // does: prefer the session's own snapshot, fall back to current batch
-      // enrollment so the two endpoints never disagree on "who counts."
+      // Roster doesn't depend on attendance readiness — resolve it up front
+      // (same fallback meetingAttendanceAnalytics uses: prefer the
+      // session's own invited-students snapshot, fall back to current
+      // batch enrollment) so it's available in the response even before
+      // attendance has been computed, matching the analytics endpoint's
+      // behavior.
       let invitedStudents: { userId: number; email: string; name?: string }[] =
         Array.isArray(session.invitedStudents) ? session.invitedStudents : [];
 
@@ -4656,6 +4588,125 @@ export class ClassesService {
         }));
       }
 
+      let readiness: {
+        ready: boolean;
+        state: string;
+        reason: string | null;
+      };
+
+      // zuvy_student_attendance_records is Zoom-only by construction — a
+      // Google Meet session structurally never has rows there, so skip the
+      // query entirely rather than always running it just to get an empty
+      // result back.
+      //
+      // Checked (for Zoom sessions) regardless of the job queue below: a
+      // session can have real attendance rows without ever having gone
+      // through it (older sessions from before that system existed, or
+      // ones populated by the daily backfill cron / manual reclassify
+      // tool, both of which write records directly and never touch
+      // zuvy_session_attendance_jobs). Fetched as full rows (not just an
+      // existence check) so the same query also supplies the raw
+      // per-record fields (id/version/createdAt/attendanceDate) needed
+      // further down — no second query against this table.
+      //
+      // Ordered ascending by id so that if duplicate rows exist for the
+      // same student (no unique constraint enforces otherwise), the Map
+      // construction below — which lets the last array element win —
+      // picks the most recently inserted row. This must match the same
+      // "latest row wins" rule AttendanceCalculationService.
+      // getUnifiedAttendanceMap uses internally, or this endpoint's
+      // id/version/createdAt/attendanceDate could end up sourced from a
+      // different physical row than the status/duration it's paired with.
+      const rawRecordRows = isZoomMeet
+        ? await db
+            .select({
+              id: zuvyStudentAttendanceRecords.id,
+              userId: zuvyStudentAttendanceRecords.userId,
+              attendanceDate: zuvyStudentAttendanceRecords.attendanceDate,
+              version: zuvyStudentAttendanceRecords.version,
+              createdAt: zuvyStudentAttendanceRecords.createdAt,
+            })
+            .from(zuvyStudentAttendanceRecords)
+            .where(eq(zuvyStudentAttendanceRecords.sessionId, sessionId))
+            .orderBy(asc(zuvyStudentAttendanceRecords.id))
+        : [];
+      const hasExistingRecords = rawRecordRows.length > 0;
+      const rawRecordByUserId = new Map(
+        rawRecordRows.map((r) => [Number(r.userId), r]),
+      );
+
+      if (isZoomMeet) {
+        const latestJobRows = await db
+          .select({
+            status: zuvySessionAttendanceJobs.status,
+            lastError: zuvySessionAttendanceJobs.lastError,
+          })
+          .from(zuvySessionAttendanceJobs)
+          .where(eq(zuvySessionAttendanceJobs.sessionId, sessionId))
+          .orderBy(desc(zuvySessionAttendanceJobs.id))
+          .limit(1);
+
+        // Deliberately NOT gated on session.status — that column is only
+        // refreshed as a side effect of unrelated endpoints
+        // (updatingStatusOfClass) and can stay stale at 'ongoing' long
+        // after the class, and its attendance, are actually done. The job
+        // row's existence/status is authoritative and always current.
+        readiness = resolveZoomAttendanceReadiness(
+          now,
+          sessionEndTime,
+          latestJobRows[0] || null,
+          hasExistingRecords,
+        );
+      } else {
+        const existingAggregate = session.meetingId
+          ? await db
+              .select({ id: zuvyStudentAttendance.id })
+              .from(zuvyStudentAttendance)
+              .where(eq(zuvyStudentAttendance.meetingId, session.meetingId))
+              .limit(1)
+          : [];
+
+        readiness = resolveGoogleMeetAttendanceReadiness(
+          now,
+          sessionEndTime,
+          hasExistingRecords || existingAggregate.length > 0,
+        );
+      }
+
+      // Single field, not split across `records`/`session.invitedStudents`/
+      // `session.studentAttendanceRecords` (an earlier version of this
+      // endpoint did — all three were different cuts of the same merge,
+      // which is redundant rather than useful). `studentAttendanceRecords`
+      // always covers every invited student (unlike analytics, which
+      // silently omits students the pipeline never processed), and carries
+      // every field analytics' version has, sourced from the DB row where
+      // one exists and filled in from session context otherwise — so a
+      // caller migrating off analytics gets a strict superset, not a
+      // narrower shape to work around. The actual merge is a pure function
+      // (buildStudentAttendanceRecords) so it's unit-testable without a DB.
+      const emptyResult = {
+        sessionId: session.id,
+        sessionStatus: session.status,
+        isZoomMeet,
+        ...readiness,
+        totalStudents: 0,
+        presentCount: 0,
+        absentCount: 0,
+        attendancePercentage: 0,
+        studentAttendanceRecords: [] as StudentAttendanceRecord[],
+      };
+
+      if (!readiness.ready) {
+        return [
+          null,
+          {
+            success: true,
+            data: emptyResult,
+            message: 'Attendance not ready yet',
+          },
+        ];
+      }
+
       const sessionRowForCalc = {
         id: session.id,
         title: session.title,
@@ -4669,25 +4720,34 @@ export class ClassesService {
         batchName: null,
       };
 
+      // getUnifiedAttendanceMap (not the raw rows fetched above) is the
+      // source of truth for status/duration: it merges the Zoom-webhook
+      // table with the legacy Google Meet table, whereas the raw rows are
+      // Zoom-only. Using it here keeps this endpoint correct for Google
+      // Meet sessions too, unlike analytics.
       const attendanceMap = await this.attendanceCalc.getUnifiedAttendanceMap(
         [sessionRowForCalc],
         { batchId: session.batchId },
       );
       const perUserMap = attendanceMap.get(session.id) ?? new Map();
 
-      const records = invitedStudents.map((student) => {
-        const entry = perUserMap.get(Number(student.userId));
-        return {
-          userId: Number(student.userId),
-          name: student.name || null,
-          email: student.email || null,
-          status: entry?.status || 'absent',
-          duration: entry?.duration ?? 0,
-        };
-      });
+      const studentAttendanceRecords: StudentAttendanceRecord[] =
+        buildStudentAttendanceRecords(
+          invitedStudents,
+          perUserMap,
+          rawRecordByUserId,
+          {
+            id: session.id,
+            batchId: session.batchId,
+            bootcampId: session.bootcampId,
+            startTime: session.startTime,
+          },
+        );
 
-      const totalStudents = records.length;
-      const presentCount = records.filter((r) => r.status === 'present').length;
+      const totalStudents = studentAttendanceRecords.length;
+      const presentCount = studentAttendanceRecords.filter(
+        (r) => r.status === 'present',
+      ).length;
       const absentCount = totalStudents - presentCount;
       const attendancePercentage =
         totalStudents > 0
@@ -4704,7 +4764,7 @@ export class ClassesService {
             presentCount,
             absentCount,
             attendancePercentage,
-            records,
+            studentAttendanceRecords,
           },
           message: 'Session attendance status fetched successfully',
         },

--- a/src/services/attendance/attendance-calculation.service.ts
+++ b/src/services/attendance/attendance-calculation.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { and, eq, inArray } from 'drizzle-orm';
+import { and, asc, eq, inArray } from 'drizzle-orm';
 import { db } from '../../db/index';
 import {
   zuvyBatchEnrollments,
@@ -139,6 +139,15 @@ export class AttendanceCalculationService {
     );
 
     if (zoomSessionIds.length > 0) {
+      // zuvy_student_attendance_records has no unique constraint on
+      // (session_id, user_id), so duplicate rows for the same student+
+      // session are possible. Ordered ascending by id so the forEach below
+      // — which lets the last-processed row win via Map.set — always
+      // prefers the most recently inserted row, deterministically. Any
+      // other reader of this table for the same session+user (e.g. the raw
+      // fields read directly in ClassesService.getSessionAttendanceStatus)
+      // must use this same "latest row wins" rule or the two can disagree
+      // about which row is authoritative for a given student.
       const rows = await db
         .select({
           sessionId: zuvyStudentAttendanceRecords.sessionId,
@@ -157,7 +166,8 @@ export class AttendanceCalculationService {
                 inArray(zuvyStudentAttendanceRecords.sessionId, zoomSessionIds),
               )
             : inArray(zuvyStudentAttendanceRecords.sessionId, zoomSessionIds),
-        );
+        )
+        .orderBy(asc(zuvyStudentAttendanceRecords.id));
 
       rows.forEach((r) => {
         setEntry(r.sessionId, Number(r.userId), {

--- a/src/services/attendance/attendance-readiness.spec.ts
+++ b/src/services/attendance/attendance-readiness.spec.ts
@@ -9,7 +9,12 @@ const afterEnd = new Date('2026-07-27T07:20:00.000Z');
 
 describe('resolveZoomAttendanceReadiness', () => {
   it('is not ready and "not_ended" when the class has not reached its end time and no job exists', () => {
-    const result = resolveZoomAttendanceReadiness(beforeEnd, endTime, null);
+    const result = resolveZoomAttendanceReadiness(
+      beforeEnd,
+      endTime,
+      null,
+      false,
+    );
     expect(result).toEqual({
       ready: false,
       state: 'not_ended',
@@ -18,7 +23,12 @@ describe('resolveZoomAttendanceReadiness', () => {
   });
 
   it('is not ready and "not_started" once past end time but no job has been created yet', () => {
-    const result = resolveZoomAttendanceReadiness(afterEnd, endTime, null);
+    const result = resolveZoomAttendanceReadiness(
+      afterEnd,
+      endTime,
+      null,
+      false,
+    );
     expect(result.ready).toBe(false);
     expect(result.state).toBe('not_started');
   });
@@ -28,31 +38,59 @@ describe('resolveZoomAttendanceReadiness', () => {
     // reported — zuvy_sessions.status can lag behind reality (it's only
     // refreshed as a side effect of unrelated endpoints), so readiness must
     // never depend on "now vs end time" once a job actually exists.
-    const result = resolveZoomAttendanceReadiness(beforeEnd, endTime, {
-      status: 'COMPLETED',
-    });
+    const result = resolveZoomAttendanceReadiness(
+      beforeEnd,
+      endTime,
+      { status: 'COMPLETED' },
+      false,
+    );
     expect(result).toEqual({ ready: true, state: 'ready', reason: null });
   });
 
   it.each(['DISCOVERED', 'PROCESSING', 'FAILED'])(
     'is "processing" (not ready) while job status is %s',
     (status) => {
-      const result = resolveZoomAttendanceReadiness(afterEnd, endTime, {
-        status,
-      });
+      const result = resolveZoomAttendanceReadiness(
+        afterEnd,
+        endTime,
+        { status },
+        false,
+      );
       expect(result.ready).toBe(false);
       expect(result.state).toBe('processing');
     },
   );
 
   it('is "failed" (not ready) once retries are exhausted, surfacing the last error', () => {
-    const result = resolveZoomAttendanceReadiness(afterEnd, endTime, {
-      status: 'PERMANENT_FAILED',
-      lastError: 'Zoom API returned 429',
-    });
+    const result = resolveZoomAttendanceReadiness(
+      afterEnd,
+      endTime,
+      { status: 'PERMANENT_FAILED', lastError: 'Zoom API returned 429' },
+      false,
+    );
     expect(result.ready).toBe(false);
     expect(result.state).toBe('failed');
     expect(result.reason).toBe('Zoom API returned 429');
+  });
+
+  it('is ready when records already exist even with no job row at all — sessions predating the job queue, or populated by the backfill cron / manual reclassify tool', () => {
+    const result = resolveZoomAttendanceReadiness(
+      afterEnd,
+      endTime,
+      null,
+      true,
+    );
+    expect(result).toEqual({ ready: true, state: 'ready', reason: null });
+  });
+
+  it('is ready when records already exist even if the latest job says PERMANENT_FAILED — a prior successful run (or another path) already produced usable data', () => {
+    const result = resolveZoomAttendanceReadiness(
+      afterEnd,
+      endTime,
+      { status: 'PERMANENT_FAILED', lastError: 'boom' },
+      true,
+    );
+    expect(result).toEqual({ ready: true, state: 'ready', reason: null });
   });
 });
 

--- a/src/services/attendance/attendance-readiness.ts
+++ b/src/services/attendance/attendance-readiness.ts
@@ -45,7 +45,19 @@ export function resolveZoomAttendanceReadiness(
   now: Date,
   sessionEndTime: Date,
   latestJob: AttendanceJobSnapshot | null,
+  hasExistingRecords: boolean,
 ): AttendanceReadiness {
+  // The job queue only reflects sessions processed by the webhook-driven
+  // pipeline. Older sessions (predating that system), or ones populated by
+  // the daily backfill cron or the manual reclassify tool, get real
+  // zuvy_student_attendance_records rows without ever having a job row at
+  // all. Checking this first, before the job, means those sessions don't
+  // get permanently stuck reporting "not started" despite already having
+  // correct data.
+  if (hasExistingRecords) {
+    return { ready: true, state: 'ready', reason: null };
+  }
+
   if (!latestJob) {
     if (now < sessionEndTime) {
       return {

--- a/src/services/attendance/attendance-record-merge.spec.ts
+++ b/src/services/attendance/attendance-record-merge.spec.ts
@@ -1,0 +1,149 @@
+import {
+  buildStudentAttendanceRecords,
+  RawAttendanceRecord,
+  StudentAttendanceStatusEntry,
+} from './attendance-record-merge';
+
+const session = {
+  id: 1958,
+  batchId: 707,
+  bootcampId: 1082,
+  startTime: '2026-07-27T06:36:00.000Z',
+};
+
+describe('buildStudentAttendanceRecords', () => {
+  it('includes every invited student, even ones with no attendance record at all', () => {
+    const invited = [
+      { userId: 1, email: 'a@x.com', name: 'A' },
+      { userId: 2, email: 'b@x.com', name: 'B' },
+    ];
+    const perUserStatus = new Map<number, StudentAttendanceStatusEntry>([
+      [1, { status: 'present', duration: 100 }],
+      // user 2 has no entry at all
+    ]);
+    const rawRecordByUserId = new Map<number, RawAttendanceRecord>();
+
+    const result = buildStudentAttendanceRecords(
+      invited,
+      perUserStatus,
+      rawRecordByUserId,
+      session,
+    );
+
+    expect(result).toHaveLength(2);
+    expect(result[1]).toMatchObject({
+      userId: 2,
+      status: 'absent',
+      duration: 0,
+      id: null,
+      version: null,
+      createdAt: null,
+    });
+  });
+
+  it('fills id/version/createdAt/attendanceDate from the raw record when one exists', () => {
+    const invited = [{ userId: 1, email: 'a@x.com', name: 'A' }];
+    const perUserStatus = new Map<number, StudentAttendanceStatusEntry>([
+      [1, { status: 'present', duration: 500 }],
+    ]);
+    const rawRecordByUserId = new Map<number, RawAttendanceRecord>([
+      [
+        1,
+        {
+          id: 9999,
+          userId: 1,
+          attendanceDate: '2026-07-27',
+          version: 'v1',
+          createdAt: '2026-07-27T07:00:00.000Z',
+        },
+      ],
+    ]);
+
+    const [record] = buildStudentAttendanceRecords(
+      invited,
+      perUserStatus,
+      rawRecordByUserId,
+      session,
+    );
+
+    expect(record).toEqual({
+      id: 9999,
+      userId: 1,
+      batchId: 707,
+      bootcampId: 1082,
+      sessionId: 1958,
+      attendanceDate: '2026-07-27',
+      status: 'present',
+      version: 'v1',
+      duration: 500,
+      createdAt: '2026-07-27T07:00:00.000Z',
+      email: 'a@x.com',
+      name: 'A',
+    });
+  });
+
+  it('falls back to the session date when no raw record exists for that student', () => {
+    const invited = [{ userId: 1, email: 'a@x.com', name: 'A' }];
+    const result = buildStudentAttendanceRecords(
+      invited,
+      new Map(),
+      new Map(),
+      session,
+    );
+
+    expect(result[0].attendanceDate).toBe('2026-07-27');
+  });
+
+  it('always populates batchId/bootcampId/sessionId from the session, never null, regardless of record existence', () => {
+    const invited = [
+      { userId: 1, email: 'a@x.com', name: 'A' },
+      { userId: 2, email: 'b@x.com', name: 'B' },
+    ];
+    const perUserStatus = new Map<number, StudentAttendanceStatusEntry>([
+      [1, { status: 'present', duration: 500 }],
+    ]);
+    const rawRecordByUserId = new Map<number, RawAttendanceRecord>([
+      [
+        1,
+        {
+          id: 1,
+          userId: 1,
+          attendanceDate: null,
+          version: null,
+          createdAt: null,
+        },
+      ],
+    ]);
+
+    const result = buildStudentAttendanceRecords(
+      invited,
+      perUserStatus,
+      rawRecordByUserId,
+      session,
+    );
+
+    for (const record of result) {
+      expect(record.batchId).toBe(707);
+      expect(record.bootcampId).toBe(1082);
+      expect(record.sessionId).toBe(1958);
+    }
+  });
+
+  it('never defaults an empty-string status to "absent" — only missing entries default', () => {
+    // Regression guard for the `||` vs `??` distinction: an explicit empty
+    // string is not the same as "no entry", even though both are falsy.
+    const invited = [{ userId: 1, email: 'a@x.com', name: 'A' }];
+    const perUserStatus = new Map<number, StudentAttendanceStatusEntry>([
+      [1, { status: '', duration: 0 }],
+    ]);
+
+    const [record] = buildStudentAttendanceRecords(
+      invited,
+      perUserStatus,
+      new Map(),
+      session,
+    );
+
+    expect(record.status).toBe('');
+  });
+});

--- a/src/services/attendance/attendance-record-merge.ts
+++ b/src/services/attendance/attendance-record-merge.ts
@@ -1,0 +1,88 @@
+export interface InvitedStudent {
+  userId: number;
+  email?: string;
+  name?: string;
+}
+
+export interface RawAttendanceRecord {
+  id: number;
+  userId: number;
+  attendanceDate: string | null;
+  version: string | null;
+  createdAt: string | null;
+}
+
+export interface StudentAttendanceStatusEntry {
+  status: string;
+  duration: number;
+}
+
+export interface StudentAttendanceRecord {
+  id: number | null;
+  userId: number;
+  batchId: number;
+  bootcampId: number;
+  sessionId: number;
+  attendanceDate: string | null;
+  status: string;
+  version: string | null;
+  duration: number;
+  createdAt: string | null;
+  email: string | null;
+  name: string | null;
+}
+
+/**
+ * Merges the invited-student roster with computed attendance status/duration
+ * and (where one exists) the raw zuvy_student_attendance_records row, into
+ * one complete record per invited student.
+ *
+ * Always covers every invited student — unlike the analytics endpoint,
+ * which silently omits students the pipeline never processed — defaulting
+ * to `absent`/`0` and `null` for the DB-row-only fields (id/version/
+ * createdAt) when no real record exists for that student.
+ *
+ * `batchId`/`bootcampId`/`sessionId` come from `session`, not from the raw
+ * record, and are never null: they're `.notNull()` columns on the session
+ * itself, known regardless of whether any individual student has a real
+ * attendance row yet.
+ *
+ * Pure and DB-free by design so this merge is unit-testable without a live
+ * database — see attendance-record-merge.spec.ts.
+ */
+export function buildStudentAttendanceRecords(
+  invitedStudents: InvitedStudent[],
+  perUserStatus: Map<number, StudentAttendanceStatusEntry>,
+  rawRecordByUserId: Map<number, RawAttendanceRecord>,
+  session: {
+    id: number;
+    batchId: number;
+    bootcampId: number;
+    startTime: string | null;
+  },
+): StudentAttendanceRecord[] {
+  const sessionDateFallback = session.startTime
+    ? new Date(session.startTime).toISOString().split('T')[0]
+    : null;
+
+  return invitedStudents.map((student) => {
+    const userId = Number(student.userId);
+    const entry = perUserStatus.get(userId);
+    const rawRecord = rawRecordByUserId.get(userId);
+
+    return {
+      id: rawRecord?.id ?? null,
+      userId,
+      batchId: session.batchId,
+      bootcampId: session.bootcampId,
+      sessionId: session.id,
+      attendanceDate: rawRecord?.attendanceDate ?? sessionDateFallback,
+      status: entry?.status ?? 'absent',
+      version: rawRecord?.version ?? null,
+      duration: entry?.duration ?? 0,
+      createdAt: rawRecord?.createdAt ?? null,
+      email: student.email || null,
+      name: student.name || null,
+    };
+  });
+}


### PR DESCRIPTION
Follow-up to the recently-added `GET /classes/attendance/:sessionId` endpoint. Three related fixes, found while migrating fields over from `/classes/analytics/:sessionId` and during a self-review of that migration:

1. Old sessions incorrectly reported "not ready" despite having real attendance data. Readiness was gated solely on the Zoom-webhook job queue (`zuvy_session_attendance_jobs`), but sessions predating that system — or populated by the daily backfill cron / manual reclassify tool — never create a job row at all. Both `resolveZoomAttendanceReadiness` and the caller now check for existing `zuvy_student_attendance_records` rows first, and treat that as authoritative regardless of job state.

2. Consolidated three overlapping response fields into one. The endpoint previously returned `records`, `session.invitedStudents`, and `session.studentAttendanceRecords` — three different cuts of the same merge. Replaced with a single `studentAttendanceRecords` array that always covers every invited student (unlike `/classes/analytics`, which silently omits students the pipeline never processed) and carries every field analytics' version has (`id`, `batchId`, `bootcampId`, `sessionId`, `attendanceDate`, `version`, `createdAt`) plus what was already there — a strict superset, sourced from the DB row where one exists and filled in from session context otherwise.

3. Fixed a data-consistency bug introduced by (2). `zuvy_student_attendance_records` has no unique constraint on `(session_id, user_id)`, so duplicate rows are possible. The new raw-fields query and the shared `getUnifiedAttendanceMap` query were both unordered, independent lookups against that table — meaning a single response entry could end up with `status`/`duration` from one physical row and `id`/`createdAt`/`version` from a *different* row for the same student. Both queries now order `ASC BY id` so they deterministically agree on "the latest row wins."

Also extracted the per-student merge logic into a pure, unit-tested function (`buildStudentAttendanceRecords`) rather than leaving it inline and untested, and stopped running the Zoom-only raw-records query for Google Meet sessions (which structurally never have rows there).