### PR TITLE
fix(cpp-template): correct numeric type inference and JSON serialization in C++ code template

### DIFF
--- a/src/controller/codingPlatform/codingPlatform.service.ts
+++ b/src/controller/codingPlatform/codingPlatform.service.ts
@@ -55,6 +55,7 @@ export class CodingPlatformService {
         switch (input.parameterType) {
           case 'int':
           case 'float':
+          case 'double':
           case 'str':
           case 'bool':
             return input.parameterValue.toString(); // Convert to string
@@ -75,6 +76,7 @@ export class CodingPlatformService {
         switch (testCase.expectedOutput.parameterType) {
           case 'int':
           case 'float':
+          case 'double':
           case 'str':
           case 'bool':
             return testCase.expectedOutput.parameterValue.toString();
@@ -726,6 +728,7 @@ export class CodingPlatformService {
           question[0].title,
           question[0].testCases[0].inputs,
           question[0].testCases[0].expectedOutput?.parameterType,
+          question[0].testCases,
         );
         if (errorGenerateTemplate) {
           return [errorGenerateTemplate];

--- a/src/helpers/cpp/cppRuntime.ts
+++ b/src/helpers/cpp/cppRuntime.ts
@@ -151,6 +151,21 @@ if (onlyQuotes) {
 return v;
 }
 
+static void printJsonString(const string &s) {
+  cout << '"';
+  for (char c : s) {
+    switch (c) {
+      case '"': cout << "\\\""; break;
+      case '\\': cout << "\\\\"; break;
+      case '\n': cout << "\\n"; break;
+      case '\r': cout << "\\r"; break;
+      case '\t': cout << "\\t"; break;
+      default: cout << c;
+    }
+  }
+  cout << '"';
+}
+
 static void printVariant(const Variant &v) {
   if (v.t == Variant::NUL) {
     cout << "null";
@@ -159,13 +174,15 @@ static void printVariant(const Variant &v) {
     cout << v.i;
   }
   else if (v.t == Variant::DBL) {
-    cout << v.d;
+    std::ostringstream oss;
+    oss << std::setprecision(15) << v.d;
+    cout << oss.str();
  }
   else if (v.t == Variant::BOOL) {
     cout << (v.b ? "true" : "false");
   }
   else if (v.t == Variant::STR) {
-    cout << v.s;
+    printJsonString(v.s);
   }
   else if (v.t == Variant::ARR) {
     cout << "[";

--- a/src/helpers/cpp/generateCpp.ts
+++ b/src/helpers/cpp/generateCpp.ts
@@ -1,17 +1,72 @@
 import { CPP_RUNTIME } from './cppRuntime';
 import { CppInputMode } from './cppInputModes';
 
+/* Recursively pull every number out of a (possibly nested) test-case value */
+function flattenNumbers(value: unknown): number[] {
+  if (Array.isArray(value)) return value.flatMap(flattenNumbers);
+  return typeof value === 'number' ? [value] : [];
+}
+
+/*
+ * Decide whether a numeric array parameter/return should be emitted as an
+ * integer (long long) or floating point (double) vector in C++.
+ *
+ * Every other generated language treats a bare numeric array as an int
+ * array (Java: int[], Python: List[int]), so `long long` is the safe
+ * default whenever we have no sample values to inspect. When real sample
+ * values ARE available, any non-integral number present in them forces
+ * `double` so genuinely fractional data still round-trips correctly.
+ */
+function inferNumericElemType(samples: unknown[]): 'long long' | 'double' {
+  const nums = samples.flatMap(flattenNumbers);
+  if (nums.length === 0) return 'long long';
+  return nums.every((n) => Number.isInteger(n)) ? 'long long' : 'double';
+}
+
 export async function generateCppTemplate(
   functionName: string,
-  parameters: Array<{ parameterName: string; parameterType: string }>,
+  parameters: Array<{
+    parameterName: string;
+    parameterType: string;
+    parameterValue?: unknown;
+  }>,
   returnType = 'void',
   options?: {
     inputMode?: CppInputMode;
     multipleTests?: boolean;
     interactive?: boolean;
+    // Every test case's raw inputs/expectedOutput, used only to infer
+    // int-vs-double for numeric array parameters/return values.
+    allTestCases?: Array<{
+      inputs?: Array<{ parameterName: string; parameterValue?: unknown }>;
+      expectedOutput?: { parameterValue?: unknown };
+    }>;
   },
 ) {
   try {
+    const paramNumericElemType = (p: {
+      parameterName: string;
+      parameterValue?: unknown;
+    }): 'long long' | 'double' => {
+      const samples: unknown[] = [];
+      for (const tc of options?.allTestCases ?? []) {
+        const match = tc?.inputs?.find(
+          (i) => i?.parameterName === p.parameterName,
+        );
+        if (match) samples.push(match.parameterValue);
+      }
+      if (samples.length === 0 && 'parameterValue' in p) {
+        samples.push(p.parameterValue);
+      }
+      return inferNumericElemType(samples);
+    };
+
+    const returnNumericElemType = (): 'long long' | 'double' => {
+      const samples = (options?.allTestCases ?? []).map(
+        (tc) => tc?.expectedOutput?.parameterValue,
+      );
+      return inferNumericElemType(samples);
+    };
     const inputMode: CppInputMode =
       options?.inputMode ||
       (parameters.some((p) =>
@@ -42,12 +97,18 @@ export async function generateCppTemplate(
     const needsRuntime =
       inputMode === 'HYBRID' ||
       returnType === 'jsonType' ||
+      returnType === 'object' ||
       parameters.some((p) =>
         ['jsonType', 'object', 'map', 'arrayOfObj'].includes(p.parameterType),
       );
 
     /* ---------- type mapping ---------- */
-    const cppType = (t: string) => {
+    // elemType only matters for arrayOfnum / arrayOfarrayOfnum; other
+    // callers can omit it.
+    const cppType = (
+      t: string,
+      elemType: 'long long' | 'double' = 'long long',
+    ) => {
       switch (t) {
         case 'int':
           return 'long long';
@@ -61,11 +122,11 @@ export async function generateCppTemplate(
         case 'str':
           return 'string';
         case 'arrayOfnum':
-          return 'vector<double>';
+          return `vector<${elemType}>`;
         case 'arrayOfStr':
           return 'vector<string>';
         case 'arrayOfarrayOfnum':
-          return 'vector<vector<double>>';
+          return `vector<vector<${elemType}>>`;
         case 'arrayOfarrayOfStr':
           return 'vector<vector<string>>';
         case 'linkedList':
@@ -81,6 +142,7 @@ export async function generateCppTemplate(
         case 'weightedGraph':
           return 'vector<vector<pair<int,int>>>';
         case 'jsonType':
+        case 'object':
           return 'Variant';
         default:
           return 'string';
@@ -88,10 +150,16 @@ export async function generateCppTemplate(
     };
 
     const paramList = parameters
-      .map((p) => `const ${cppType(p.parameterType)}& ${p.parameterName}`)
+      .map(
+        (p) =>
+          `const ${cppType(p.parameterType, paramNumericElemType(p))}& ${p.parameterName}`,
+      )
       .join(', ');
 
-    const returnCppType = returnType === 'void' ? 'void' : cppType(returnType);
+    const returnCppType =
+      returnType === 'void'
+        ? 'void'
+        : cppType(returnType, returnNumericElemType());
 
     /* ---------- SIMPLE input ---------- */
     const simpleInput = parameters
@@ -146,7 +214,7 @@ ${needsIgnore ? "cin.ignore(numeric_limits<streamsize>::max(), '\\n');" : ''}
           return `
   int ${p.parameterName}_n;
   cin >> ${p.parameterName}_n;
-  vector<double> ${p.parameterName}(${p.parameterName}_n);
+  vector<${paramNumericElemType(p)}> ${p.parameterName}(${p.parameterName}_n);
   for (int i = 0; i < ${p.parameterName}_n; ++i) cin >> ${p.parameterName}[i];
 `;
         }
@@ -206,6 +274,23 @@ ${parameters
     ${name} = v_${name}.i;
 `;
 
+          case 'float':
+          case 'double':
+            return `
+  double ${name} = 0;
+  if (v_${name}.t == Variant::INT)
+    ${name} = (double)v_${name}.i;
+  else if (v_${name}.t == Variant::DBL)
+    ${name} = v_${name}.d;
+`;
+
+          case 'char':
+            return `
+  char ${name} = '\\0';
+  if (v_${name}.t == Variant::STR && !v_${name}.s.empty())
+    ${name} = v_${name}.s[0];
+`;
+
           case 'bool':
             return `
   bool ${name} = false;
@@ -220,15 +305,16 @@ ${parameters
     ${name} = v_${name}.s;
 `;
 
-          case 'arrayOfnum':
+          case 'arrayOfnum': {
+            const elemType = paramNumericElemType(p);
             return `
-  vector<double> ${name};
+  vector<${elemType}> ${name};
   if (v_${name}.t == Variant::ARR) {
     for (auto &el : v_${name}.a) {
       if (el.t == Variant::INT) {
-        ${name}.push_back((double)el.i);
+        ${name}.push_back((${elemType})el.i);
       } else if (el.t == Variant::DBL) {
-        ${name}.push_back(el.d);
+        ${name}.push_back((${elemType})el.d);
       } else {
         cerr << "Type error: expected numeric value in array '${name}'" << endl;
         return 0;
@@ -236,6 +322,7 @@ ${parameters
     }
   }
 `;
+          }
 
           case 'arrayOfStr':
             return `
@@ -251,21 +338,22 @@ ${parameters
   }
 `;
 
-          case 'arrayOfarrayOfnum':
+          case 'arrayOfarrayOfnum': {
+            const elemType = paramNumericElemType(p);
             return `
-  vector<vector<double>> ${name};
+  vector<vector<${elemType}>> ${name};
   if (v_${name}.t == Variant::ARR) {
     for (auto &row : v_${name}.a) {
       if (row.t != Variant::ARR) {
         cerr << "Type error: expected array in '${name}'" << endl;
         return 0;
       }
-      vector<double> temp;
+      vector<${elemType}> temp;
       for (auto &el : row.a) {
         if (el.t == Variant::INT) {
-          temp.push_back((double)el.i);
+          temp.push_back((${elemType})el.i);
         } else if (el.t == Variant::DBL) {
-          temp.push_back(el.d);
+          temp.push_back((${elemType})el.d);
         } else {
           cerr << "Type error: expected numeric value in nested array '${name}'" << endl;
           return 0;
@@ -275,6 +363,7 @@ ${parameters
     }
   }
 `;
+          }
 
           case 'arrayOfarrayOfStr':
             return `
@@ -329,6 +418,7 @@ ${parameters
 `;
 
           case 'jsonType':
+          case 'object':
             return `
   Variant ${name} = v_${name};
 `;
@@ -374,7 +464,21 @@ cout << out;
         return `printVector(result);`;
       }
 
-      if (returnType === 'jsonType') {
+      if (
+        returnType === 'arrayOfarrayOfnum' ||
+        returnType === 'arrayOfarrayOfStr'
+      ) {
+        return `
+  cout << "[";
+  for (size_t i = 0; i < result.size(); i++) {
+    if (i) cout << ",";
+    printVector(result[i]);
+  }
+  cout << "]";
+`;
+      }
+
+      if (returnType === 'jsonType' || returnType === 'object') {
         return `printVariant(result);`;
       }
       return `cout << result;`;
@@ -432,28 +536,18 @@ void printVector(const vector<T>& v) {
 }
 
 // ===== Float vector printer (DO NOT REMOVE) =====
+// Elements print with their natural minimal representation (5 stays "5",
+// 2.5 stays "2.5") to match plain JSON serialization of a numeric array,
+// which never pads whole numbers with a trailing ".0" the way a scalar
+// float/double return value does.
 template <>
 void printVector<double>(const vector<double>& v) {
   cout << "[";
   for (size_t i = 0; i < v.size(); i++) {
     if (i) cout << ",";
-
     std::ostringstream oss;
-    if (std::floor(v[i]) == v[i]) {
-    oss << std::fixed << std::setprecision(1) << v[i];
-    } else {
     oss << std::setprecision(15) << v[i];
-    }
-
-    string out = oss.str();
-
-    if (out.find('.') != string::npos) {
-    while (!out.empty() && out.back() == '0') out.pop_back();
-    if (!out.empty() && out.back() == '.') out.push_back('0');
-    }
-
-    cout << out;
-
+    cout << oss.str();
   }
   cout << "]";
 }

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -268,7 +268,12 @@ export const typeMappings = {
   },
 };
 
-export async function generateTemplates(functionName, parameters, returnType) {
+export async function generateTemplates(
+  functionName,
+  parameters,
+  returnType,
+  allTestCases?,
+) {
   try {
     functionName = functionName.replace(/ /g, '_').toLowerCase();
     /**
@@ -337,6 +342,7 @@ rl.on('close', () => {
       functionName,
       parameters,
       returnType,
+      { allTestCases },
     );
     if (errorCppTemplate) {
       return [errorCppTemplate, null];


### PR DESCRIPTION
- C++ template bugs that silently broke a large share of coding questions (verified against the real Judge0 GCC 14.1.0 compiler with live DB data — 86+ questions were affected).

- arrayOfnum/arrayOfarrayOfnum forced to vector<double> unconditionally — caused integer array outputs (e.g. [1,3,12,0,0]) to print as [1.0,3.0,12.0,0.0,0.0], mismatching the judge's plain JSON output. Now infers long long vs double from actual test-case values.

- object-typed parameters, and scalar float/double/char mixed into a hybrid-mode question, were declared but never assigned — guaranteed "undeclared identifier" compile error. Added the missing conversion cases.

- printVector<double> forced .0 on whole numbers even inside mixed int/fractional arrays (e.g. [2.5, 5, 7.5] → [2.5,5.0,7.5]) — now prints natural minimal representation matching JSON serialization.

- printVariant() printed string values without quotes inside jsonType output (e.g. {"description":Yes} instead of {"description":"Yes"}) — any JSON output containing a string field failed. Added proper quoting/escaping; also fixed nested float precision (was truncating to 6 digits).

- submitCodeBatch type switch was missing 'double' (only had 'float') — threw Unsupported input/output type before reaching Judge0, in any language.

- Added output support for arrayOfarrayOfnum/arrayOfarrayOfStr return types (previously non-compiling — no code path existed at all).