### PR TITLE
Feature/course leaderboard points

### DIFF
--- a/drizzle/0002_tired_quasimodo.sql
+++ b/drizzle/0002_tired_quasimodo.sql
@@ -866,32 +866,6 @@ ON "zuvy_user_feature_flags" ("user_id");
 
 
 
-
-
-
-
-SELECT id, name
-FROM zuvy_course_modules
-WHERE id = 964;
-
-
-SELECT id, title
-FROM zuvy_course_projects
-WHERE id = 153;
-
-
-SELECT id, name, project_id
-FROM zuvy_course_modules
-WHERE id = 950;
-
-
-
-SELECT id, title
-FROM zuvy_course_projects
-WHERE id = 153;
-
-
-
-SELECT project_id
-FROM zuvy_course_modules
-WHERE id = 96;
+ALTER TABLE zuvy_learner_leaderboard
+ADD COLUMN article_points INTEGER DEFAULT 0,
+ADD COLUMN video_points INTEGER DEFAULT 0;

--- a/drizzle/0002_tired_quasimodo.sql
+++ b/drizzle/0002_tired_quasimodo.sql
@@ -879,3 +879,8 @@ WHERE a.id < b.id
   AND a.bootcamp_id = b.bootcamp_id;
 
 ALTER TABLE "main"."zuvy_batch_enrollments" ADD CONSTRAINT "zuvy_batch_enrollments_user_id_bootcamp_id_uniq" UNIQUE ("user_id", "bootcamp_id");
+
+
+
+
+

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -5163,6 +5163,8 @@ export const zuvyLearnerLeaderboard = main.table(
     attendancePoints: integer('attendance_points').default(0),
     recordingPoints: integer('recording_points').default(0),
     assignmentPoints: integer('assignment_points').default(0),
+    articlePoints: integer('article_points').default(0),
+    videoPoints: integer('video_points').default(0),
     totalPoints: integer('total_points').default(0),
     lastActivityAt: timestamp('last_activity_at', {
       withTimezone: true,

--- a/src/controller/leaderboard/leaderboard.service.ts
+++ b/src/controller/leaderboard/leaderboard.service.ts
@@ -223,6 +223,12 @@ export class LeaderboardService {
             zuvyOutsourseCodingQuestions.id,
           ),
         )
+
+        .innerJoin(
+          zuvyBootcamps,
+          eq(zuvyOutsourseCodingQuestions.bootcampId, zuvyBootcamps.id),
+        )
+
         .leftJoin(
           zuvyOutsourseAssessments,
           eq(
@@ -753,54 +759,52 @@ export class LeaderboardService {
     >();
 
     try {
-      const projectSubmissions = await db
+      const assignmentSubmissions = await db
         .select({
-          userId: zuvyProjectTracking.userId,
-          bootcampId: zuvyProjectTracking.bootcampId,
-          grades: zuvyProjectTracking.grades,
-          isChecked: zuvyProjectTracking.isChecked,
-          createdAt: zuvyProjectTracking.createdAt,
-          updatedAt: zuvyProjectTracking.updatedAt,
+          userId: zuvyAssignmentSubmission.userId,
+          bootcampId: zuvyAssignmentSubmission.bootcampId,
+          chapterId: zuvyAssignmentSubmission.chapterId,
+          createdAt: zuvyAssignmentSubmission.createdAt,
+          timeLimit: zuvyAssignmentSubmission.timeLimit,
         })
-        .from(zuvyProjectTracking)
-        .where(sql`${zuvyProjectTracking.bootcampId} IS NOT NULL`);
+        .from(zuvyAssignmentSubmission)
+        .innerJoin(
+          zuvyBootcamps,
+          eq(zuvyAssignmentSubmission.bootcampId, zuvyBootcamps.id),
+        )
+        .where(sql`${zuvyAssignmentSubmission.bootcampId} IS NOT NULL`);
 
-      if (projectSubmissions.length === 0) {
-        this.logger.log('No project submissions found');
+      if (assignmentSubmissions.length === 0) {
+        this.logger.log('No assignment submissions found');
         return assignmentMap;
       }
 
-      this.logger.log(`Found ${projectSubmissions.length} project submissions`);
+      this.logger.log(
+        `Found ${assignmentSubmissions.length} assignment submissions`,
+      );
 
-      for (const submission of projectSubmissions) {
-        if (!submission.userId || !submission.bootcampId) {
+      for (const submission of assignmentSubmissions) {
+        if (
+          !submission.userId ||
+          !submission.bootcampId ||
+          !submission.chapterId
+        ) {
           continue;
         }
 
         const key = `${submission.userId}-${submission.bootcampId}`;
 
-        const attemptPoints = 5;
+        const attemptPoints = 10;
 
-        const submissionBonus = submission.isChecked ? 3 : 0;
+        const bonusPoints =
+          submission.createdAt &&
+          submission.timeLimit &&
+          new Date(submission.createdAt).getTime() <=
+            new Date(submission.timeLimit).getTime()
+            ? 5
+            : 0;
 
-        let scorePoints = 0;
-        if (submission.grades !== null && submission.grades !== undefined) {
-          const gradePercentage = submission.grades;
-          if (gradePercentage >= 90) {
-            scorePoints = 12;
-          } else if (gradePercentage >= 75) {
-            scorePoints = 9;
-          } else if (gradePercentage >= 50) {
-            scorePoints = 6;
-          } else if (gradePercentage > 0) {
-            scorePoints = 3;
-          } else {
-            scorePoints = 0;
-          }
-        }
-
-        const totalAssignmentPoints =
-          attemptPoints + submissionBonus + scorePoints;
+        const totalAssignmentPoints = attemptPoints + bonusPoints;
 
         const entry = assignmentMap.get(key) || {
           chapterPoints: new Map<number, number>(),
@@ -808,11 +812,25 @@ export class LeaderboardService {
           lastActivityAt: new Date().toISOString(),
         };
 
+        this.logger.log(
+          `ASSIGNMENT LEADERBOARD DEBUG: learner=${submission.userId}, bootcamp=${submission.bootcampId}, chapter=${submission.chapterId}, attempt=${attemptPoints}, bonus=${bonusPoints}, total=${totalAssignmentPoints}`,
+        );
+
         entry.assignmentPoints += totalAssignmentPoints;
-        entry.lastActivityAt =
-          submission.updatedAt ||
-          submission.createdAt ||
-          new Date().toISOString();
+
+        this.logger.log(
+          `ASSIGNMENT MAP TOTAL: learner=${submission.userId}, bootcamp=${submission.bootcampId}, assignmentPoints=${entry.assignmentPoints}`,
+        );
+
+        const currentChapterPoints =
+          entry.chapterPoints.get(submission.chapterId) ?? 0;
+
+        entry.chapterPoints.set(
+          submission.chapterId,
+          currentChapterPoints + totalAssignmentPoints,
+        );
+
+        entry.lastActivityAt = submission.createdAt || new Date().toISOString();
 
         assignmentMap.set(key, entry);
       }
@@ -1203,6 +1221,10 @@ export class LeaderboardService {
               timeLimit: zuvyAssignmentSubmission.timeLimit,
             })
             .from(zuvyAssignmentSubmission)
+            .innerJoin(
+              zuvyBootcamps,
+              eq(zuvyAssignmentSubmission.bootcampId, zuvyBootcamps.id),
+            )
             .where(
               and(
                 eq(zuvyAssignmentSubmission.userId, userId),
@@ -1627,6 +1649,11 @@ export class LeaderboardService {
         const assignmentEntry = assignmentMap.get(
           `${entry.learnerId}-${entry.bootcampId}`,
         );
+
+        this.logger.log(
+          `ASSIGNMENT UPDATE DEBUG: learner=${entry.learnerId}, bootcamp=${entry.bootcampId}, assignmentPoints=${assignmentEntry?.assignmentPoints}`,
+        );
+
         const videoEntry = videoMap.get(
           `${entry.learnerId}-${entry.bootcampId}`,
         );

--- a/src/controller/leaderboard/leaderboard.service.ts
+++ b/src/controller/leaderboard/leaderboard.service.ts
@@ -939,11 +939,32 @@ export class LeaderboardService {
     userId: number,
     bootcampId: number,
     chapterIds: number[],
-  ): Promise<Map<number, number>> {
+  ): Promise<{
+    chapterPointsMap: Map<number, number>;
+    assignmentBreakdownMap: Map<
+      number,
+      {
+        assignment: number;
+        bonus: number;
+        performance: number;
+      }
+    >;
+  }> {
     const chapterPointsMap = new Map<number, number>();
+    const assignmentBreakdownMap = new Map<
+      number,
+      {
+        assignment: number;
+        bonus: number;
+        performance: number;
+      }
+    >();
 
     if (!chapterIds.length) {
-      return chapterPointsMap;
+      return {
+        chapterPointsMap,
+        assignmentBreakdownMap,
+      };
     }
 
     // 1. Current module ke chapters
@@ -1213,18 +1234,38 @@ export class LeaderboardService {
         if (submission.chapterId == null) {
           continue;
         }
+
         const attemptPoints = 5;
-        const bonusPoints = this.calculateOnTimeBonusPoints(
-          submission.createdAt,
-          submission.timeLimit,
-        );
+
+        const submittedSecond = submission.createdAt
+          ? Math.floor(new Date(submission.createdAt).getTime() / 1000)
+          : null;
+
+        const deadlineSecond = submission.timeLimit
+          ? Math.floor(new Date(submission.timeLimit).getTime() / 1000)
+          : null;
+
+        const bonusPoints =
+          submittedSecond !== null &&
+          deadlineSecond !== null &&
+          submittedSecond <= deadlineSecond
+            ? 5
+            : 0;
+
         const totalPoints = attemptPoints + bonusPoints;
 
         const existingPoints = chapterPointsMap.get(submission.chapterId) ?? 0;
+
         chapterPointsMap.set(
           submission.chapterId,
           existingPoints + totalPoints,
         );
+
+        assignmentBreakdownMap.set(submission.chapterId, {
+          assignment: attemptPoints,
+          bonus: bonusPoints,
+          performance: 0,
+        });
       }
     }
 
@@ -1301,7 +1342,10 @@ export class LeaderboardService {
       }
     }
 
-    return chapterPointsMap;
+    return {
+      chapterPointsMap,
+      assignmentBreakdownMap,
+    };
   }
 
   async updateLeaderboard(): Promise<{
@@ -1432,23 +1476,60 @@ export class LeaderboardService {
         `Processing ${leaderboardMap.size} unique learner-bootcamp combinations`,
       );
 
+      const learnerIds = Array.from(
+        new Set(Array.from(allKeys, (key) => Number(key.split('-')[0]))),
+      );
+      const bootcampIds = Array.from(
+        new Set(Array.from(allKeys, (key) => Number(key.split('-')[1]))),
+      );
+
+      const existingEntries =
+        learnerIds.length > 0 && bootcampIds.length > 0
+          ? await db
+              .select({
+                id: zuvyLearnerLeaderboard.id,
+                learnerId: zuvyLearnerLeaderboard.learnerId,
+                bootcampId: zuvyLearnerLeaderboard.bootcampId,
+                assessmentPoints: zuvyLearnerLeaderboard.assessmentPoints,
+                codingPoints: zuvyLearnerLeaderboard.codingPoints,
+                quizPoints: zuvyLearnerLeaderboard.quizPoints,
+                attendancePoints: zuvyLearnerLeaderboard.attendancePoints,
+                recordingPoints: zuvyLearnerLeaderboard.recordingPoints,
+                assignmentPoints: zuvyLearnerLeaderboard.assignmentPoints,
+                videoPoints: zuvyLearnerLeaderboard.videoPoints,
+                articlePoints: zuvyLearnerLeaderboard.articlePoints,
+                totalPoints: zuvyLearnerLeaderboard.totalPoints,
+                lastActivityAt: zuvyLearnerLeaderboard.lastActivityAt,
+              })
+              .from(zuvyLearnerLeaderboard)
+              .where(
+                and(
+                  inArray(zuvyLearnerLeaderboard.learnerId, learnerIds),
+                  inArray(zuvyLearnerLeaderboard.bootcampId, bootcampIds),
+                ),
+              )
+          : [];
+
+      const existingEntryMap = new Map<
+        string,
+        (typeof existingEntries)[number]
+      >();
+      for (const existingEntry of existingEntries) {
+        existingEntryMap.set(
+          `${existingEntry.learnerId}-${existingEntry.bootcampId}`,
+          existingEntry,
+        );
+      }
+
       let updatedCount = 0;
 
       for (const entry of leaderboardMap.values()) {
         try {
-          const existingEntry = await db
-            .select()
-            .from(zuvyLearnerLeaderboard)
-            .where(
-              and(
-                eq(zuvyLearnerLeaderboard.learnerId, entry.learnerId),
-                eq(zuvyLearnerLeaderboard.bootcampId, entry.bootcampId),
-              ),
-            );
+          const existing = existingEntryMap.get(
+            `${entry.learnerId}-${entry.bootcampId}`,
+          );
 
-          if (existingEntry.length > 0) {
-            const existing = existingEntry[0];
-
+          if (existing) {
             const assessmentEntry = assessmentMap.get(
               `${entry.learnerId}-${entry.bootcampId}`,
             );

--- a/src/controller/leaderboard/leaderboard.service.ts
+++ b/src/controller/leaderboard/leaderboard.service.ts
@@ -1236,7 +1236,7 @@ export class LeaderboardService {
 
       for (const quiz of quizCompletions) {
         if (quiz.chapterId != null) {
-          chapterPointsMap.set(quiz.chapterId, 5);
+          chapterPointsMap.set(quiz.chapterId, 10);
         }
       }
     }

--- a/src/controller/leaderboard/leaderboard.service.ts
+++ b/src/controller/leaderboard/leaderboard.service.ts
@@ -26,8 +26,9 @@ import {
   zuvyCourseModules,
   zuvyBootcamps,
   zuvyBatchEnrollments,
+  zuvyAssignmentSubmission,
 } from '../../../drizzle/schema';
-import { eq, and, sql } from 'drizzle-orm';
+import { eq, and, sql, inArray, isNotNull } from 'drizzle-orm';
 
 @Injectable()
 export class LeaderboardService {
@@ -105,6 +106,7 @@ export class LeaderboardService {
     Map<
       string,
       {
+        chapterPoints: Map<number, number>;
         assessmentPoints: number;
         lastActivityAt: string;
       }
@@ -113,6 +115,7 @@ export class LeaderboardService {
     const assessmentMap = new Map<
       string,
       {
+        chapterPoints: Map<number, number>;
         assessmentPoints: number;
         lastActivityAt: string;
       }
@@ -160,6 +163,7 @@ export class LeaderboardService {
         );
 
         const entry = assessmentMap.get(key) || {
+          chapterPoints: new Map<number, number>(),
           assessmentPoints: 0,
           lastActivityAt: new Date().toISOString(),
         };
@@ -186,6 +190,7 @@ export class LeaderboardService {
     Map<
       string,
       {
+        chapterPoints: Map<number, number>;
         codingPoints: number;
         lastActivityAt: string;
       }
@@ -194,6 +199,7 @@ export class LeaderboardService {
     const codingMap = new Map<
       string,
       {
+        chapterPoints: Map<number, number>;
         codingPoints: number;
         lastActivityAt: string;
       }
@@ -204,6 +210,7 @@ export class LeaderboardService {
         .select({
           userId: zuvyPracticeCode.userId,
           bootcampId: zuvyOutsourseCodingQuestions.bootcampId,
+          chapterId: zuvyOutsourseCodingQuestions.chapterId,
           submittedAt: zuvyPracticeCode.createdAt,
           deadline: zuvyOutsourseAssessments.deadline,
           practiceCodeId: zuvyPracticeCode.id,
@@ -263,11 +270,22 @@ export class LeaderboardService {
 
         const key = `${submission.userId}-${submission.bootcampId}`;
         const entry = codingMap.get(key) || {
+          chapterPoints: new Map<number, number>(),
           codingPoints: 0,
           lastActivityAt: new Date().toISOString(),
         };
 
         entry.codingPoints += pointsBreakdown.totalCodingPoints;
+
+        if (submission.chapterId) {
+          const currentChapterPoints =
+            entry.chapterPoints.get(submission.chapterId) ?? 0;
+
+          entry.chapterPoints.set(
+            submission.chapterId,
+            currentChapterPoints + pointsBreakdown.totalCodingPoints,
+          );
+        }
         entry.lastActivityAt =
           submission.submittedAt || new Date().toISOString();
 
@@ -289,6 +307,7 @@ export class LeaderboardService {
     Map<
       string,
       {
+        chapterPoints: Map<number, number>;
         quizPoints: number;
         lastActivityAt: string;
       }
@@ -339,6 +358,7 @@ export class LeaderboardService {
       const quizMap = new Map<
         string,
         {
+          chapterPoints: Map<number, number>;
           quizPoints: number;
           lastActivityAt: string;
         }
@@ -371,6 +391,7 @@ export class LeaderboardService {
         const totalQuizPoints = attemptPoints + bonusPoints + scorePoints;
 
         const entry = quizMap.get(key) || {
+          chapterPoints: new Map<number, number>(),
           quizPoints: 0,
           lastActivityAt: new Date().toISOString(),
         };
@@ -518,6 +539,7 @@ export class LeaderboardService {
     Map<
       string,
       {
+        chapterPoints: Map<number, number>;
         recordingPoints: number;
         lastActivityAt: string;
       }
@@ -526,6 +548,7 @@ export class LeaderboardService {
     const recordingMap = new Map<
       string,
       {
+        chapterPoints: Map<number, number>;
         recordingPoints: number;
         lastActivityAt: string;
       }
@@ -587,6 +610,7 @@ export class LeaderboardService {
 
         if (!recordingMap.has(key)) {
           recordingMap.set(key, {
+            chapterPoints: new Map<number, number>(),
             recordingPoints: 0,
             lastActivityAt: completion.completedAt || new Date().toISOString(),
           });
@@ -624,6 +648,7 @@ export class LeaderboardService {
     Map<
       string,
       {
+        chapterPoints: Map<number, number>;
         assignmentPoints: number;
         lastActivityAt: string;
       }
@@ -632,6 +657,7 @@ export class LeaderboardService {
     const assignmentMap = new Map<
       string,
       {
+        chapterPoints: Map<number, number>;
         assignmentPoints: number;
         lastActivityAt: string;
       }
@@ -688,6 +714,7 @@ export class LeaderboardService {
           attemptPoints + submissionBonus + scorePoints;
 
         const entry = assignmentMap.get(key) || {
+          chapterPoints: new Map<number, number>(),
           assignmentPoints: 0,
           lastActivityAt: new Date().toISOString(),
         };
@@ -720,6 +747,7 @@ export class LeaderboardService {
     Map<
       string,
       {
+        chapterPoints: Map<number, number>;
         videoPoints: number;
         lastActivityAt: string;
       }
@@ -728,6 +756,7 @@ export class LeaderboardService {
     const videoMap = new Map<
       string,
       {
+        chapterPoints: Map<number, number>;
         videoPoints: number;
         lastActivityAt: string;
       }
@@ -777,6 +806,7 @@ export class LeaderboardService {
         completionsByLearnerBootcamp.get(key)!.add(completion.chapterId);
 
         videoMap.set(key, {
+          chapterPoints: new Map<number, number>(),
           videoPoints: 0,
           lastActivityAt: completion.completedAt || new Date().toISOString(),
         });
@@ -788,6 +818,10 @@ export class LeaderboardService {
         const entry = videoMap.get(key);
 
         if (entry) {
+          for (const chapterId of chapterSet) {
+            entry.chapterPoints.set(chapterId, pointsPerVideo);
+          }
+
           entry.videoPoints = chapterSet.size * pointsPerVideo;
         }
       }
@@ -809,6 +843,7 @@ export class LeaderboardService {
     Map<
       string,
       {
+        chapterPoints: Map<number, number>;
         articlePoints: number;
         lastActivityAt: string;
       }
@@ -817,6 +852,7 @@ export class LeaderboardService {
     const articleMap = new Map<
       string,
       {
+        chapterPoints: Map<number, number>;
         articlePoints: number;
         lastActivityAt: string;
       }
@@ -866,17 +902,22 @@ export class LeaderboardService {
         completionsByLearnerBootcamp.get(key)!.add(completion.chapterId);
 
         articleMap.set(key, {
+          chapterPoints: new Map<number, number>(),
           articlePoints: 0,
           lastActivityAt: completion.completedAt || new Date().toISOString(),
         });
       }
 
       for (const [key, chapterSet] of completionsByLearnerBootcamp) {
-        const pointsPerArticle = 5;
+        const pointsPerArticle = 10;
 
         const entry = articleMap.get(key);
 
         if (entry) {
+          for (const chapterId of chapterSet) {
+            entry.chapterPoints.set(chapterId, pointsPerArticle);
+          }
+
           entry.articlePoints = chapterSet.size * pointsPerArticle;
         }
       }
@@ -892,6 +933,375 @@ export class LeaderboardService {
 
       return articleMap;
     }
+  }
+
+  async getChapterWisePoints(
+    userId: number,
+    bootcampId: number,
+    chapterIds: number[],
+  ): Promise<Map<number, number>> {
+    const chapterPointsMap = new Map<number, number>();
+
+    if (!chapterIds.length) {
+      return chapterPointsMap;
+    }
+
+    // 1. Current module ke chapters
+    const chapters = await db
+      .select({
+        chapterId: zuvyModuleChapter.id,
+        topicId: zuvyModuleChapter.topicId,
+      })
+      .from(zuvyModuleChapter)
+      .where(inArray(zuvyModuleChapter.id, chapterIds));
+
+    // 2. Sab chapters ko initially 0
+    for (const chapter of chapters) {
+      if (chapter.chapterId != null) {
+        chapterPointsMap.set(chapter.chapterId, 0);
+      }
+    }
+
+    // Topic 1: Video (working; don't break)
+    const videoChapterIds = chapters
+      .filter((chapter) => chapter.topicId === 1 && chapter.chapterId != null)
+      .map((chapter) => chapter.chapterId as number);
+
+    if (videoChapterIds.length > 0) {
+      const videoCompletions = await db
+        .select({
+          chapterId: zuvyChapterTracking.chapterId,
+        })
+        .from(zuvyChapterTracking)
+        .innerJoin(
+          zuvyModuleChapter,
+          eq(zuvyChapterTracking.chapterId, zuvyModuleChapter.id),
+        )
+        .innerJoin(
+          zuvyCourseModules,
+          eq(zuvyModuleChapter.moduleId, zuvyCourseModules.id),
+        )
+        .where(
+          and(
+            eq(zuvyChapterTracking.userId, BigInt(userId)),
+            eq(zuvyCourseModules.bootcampId, bootcampId),
+            eq(zuvyModuleChapter.topicId, 1),
+            inArray(zuvyChapterTracking.chapterId, videoChapterIds),
+          ),
+        );
+
+      for (const video of videoCompletions) {
+        if (video.chapterId != null) {
+          chapterPointsMap.set(video.chapterId, 10);
+        }
+      }
+    }
+
+    // Topic 2: Article (working; don't break)
+    const articleChapterIds = chapters
+      .filter((chapter) => chapter.topicId === 2 && chapter.chapterId != null)
+      .map((chapter) => chapter.chapterId as number);
+
+    if (articleChapterIds.length > 0) {
+      const articleCompletions = await db
+        .select({
+          chapterId: zuvyChapterTracking.chapterId,
+        })
+        .from(zuvyChapterTracking)
+        .innerJoin(
+          zuvyModuleChapter,
+          eq(zuvyChapterTracking.chapterId, zuvyModuleChapter.id),
+        )
+        .innerJoin(
+          zuvyCourseModules,
+          eq(zuvyModuleChapter.moduleId, zuvyCourseModules.id),
+        )
+        .where(
+          and(
+            eq(zuvyChapterTracking.userId, BigInt(userId)),
+            eq(zuvyCourseModules.bootcampId, bootcampId),
+            eq(zuvyModuleChapter.topicId, 2),
+            inArray(zuvyChapterTracking.chapterId, articleChapterIds),
+          ),
+        );
+
+      for (const article of articleCompletions) {
+        if (article.chapterId != null) {
+          chapterPointsMap.set(article.chapterId, 5);
+        }
+      }
+    }
+
+    // Topic 3: Coding
+    const codingChapterIds = chapters
+      .filter((chapter) => chapter.topicId === 3 && chapter.chapterId != null)
+      .map((chapter) => chapter.chapterId as number);
+
+    if (codingChapterIds.length > 0) {
+      const codingSubmissions = await db
+        .select({
+          chapterId: zuvyOutsourseCodingQuestions.chapterId,
+          submittedAt: zuvyPracticeCode.createdAt,
+          deadline: zuvyOutsourseAssessments.deadline,
+          practiceCodeId: zuvyPracticeCode.id,
+        })
+        .from(zuvyPracticeCode)
+        .leftJoin(
+          zuvyOutsourseCodingQuestions,
+          eq(
+            zuvyPracticeCode.codingOutsourseId,
+            zuvyOutsourseCodingQuestions.id,
+          ),
+        )
+        .leftJoin(
+          zuvyOutsourseAssessments,
+          eq(
+            zuvyOutsourseCodingQuestions.assessmentOutsourseId,
+            zuvyOutsourseAssessments.id,
+          ),
+        )
+        .where(
+          and(
+            eq(zuvyPracticeCode.userId, BigInt(userId)),
+            eq(zuvyOutsourseCodingQuestions.bootcampId, bootcampId),
+            inArray(zuvyOutsourseCodingQuestions.chapterId, codingChapterIds),
+          ),
+        );
+
+      if (codingSubmissions.length > 0) {
+        const practiceCodeIds = codingSubmissions.map((s) => s.practiceCodeId);
+
+        const failedTestCases = await db
+          .select({
+            submissionId: zuvyTestCasesSubmission.submissionId,
+          })
+          .from(zuvyTestCasesSubmission)
+          .where(
+            and(
+              inArray(zuvyTestCasesSubmission.submissionId, practiceCodeIds),
+              sql`${zuvyTestCasesSubmission.status} != 'Accepted'`,
+            ),
+          );
+
+        const failedSubmissionIdsSet = new Set(
+          failedTestCases.map((tc) => tc.submissionId),
+        );
+
+        for (const submission of codingSubmissions) {
+          if (submission.chapterId == null) {
+            continue;
+          }
+          const allTestCasesPassed = !failedSubmissionIdsSet.has(
+            submission.practiceCodeId,
+          );
+
+          const pointsBreakdown = this.calculateTotalCodingPoints(
+            submission.submittedAt,
+            submission.deadline,
+            allTestCasesPassed,
+          );
+
+          const existingPoints =
+            chapterPointsMap.get(submission.chapterId) ?? 0;
+          chapterPointsMap.set(
+            submission.chapterId,
+            existingPoints + pointsBreakdown.totalCodingPoints,
+          );
+        }
+      }
+    }
+
+    // Topic 4: Quiz
+    const quizChapterIds = chapters
+      .filter((chapter) => chapter.topicId === 4 && chapter.chapterId != null)
+      .map((chapter) => chapter.chapterId as number);
+
+    if (quizChapterIds.length > 0) {
+      const quizSubmissions = await db
+        .select({
+          chapterId: zuvyOutsourseQuizzes.chapterId,
+          mcqScore: zuvyAssessmentSubmission.mcqScore,
+          requiredMCQScore: zuvyAssessmentSubmission.requiredMCQScore,
+          submittedAt: zuvyAssessmentSubmission.submitedAt,
+          deadline: zuvyOutsourseAssessments.deadline,
+          createdAt: zuvyQuizTracking.createdAt,
+        })
+        .from(zuvyQuizTracking)
+        .leftJoin(
+          zuvyAssessmentSubmission,
+          eq(
+            zuvyQuizTracking.assessmentSubmissionId,
+            zuvyAssessmentSubmission.id,
+          ),
+        )
+        .leftJoin(
+          zuvyOutsourseQuizzes,
+          eq(zuvyQuizTracking.questionId, zuvyOutsourseQuizzes.id),
+        )
+        .leftJoin(
+          zuvyOutsourseAssessments,
+          eq(
+            zuvyOutsourseQuizzes.assessmentOutsourseId,
+            zuvyOutsourseAssessments.id,
+          ),
+        )
+        .where(
+          and(
+            eq(zuvyQuizTracking.userId, userId),
+            eq(zuvyOutsourseQuizzes.bootcampId, bootcampId),
+            inArray(zuvyOutsourseQuizzes.chapterId, quizChapterIds),
+          ),
+        );
+
+      for (const submission of quizSubmissions) {
+        if (submission.chapterId == null) {
+          continue;
+        }
+
+        let quizPercentage = 0;
+
+        if (
+          submission.mcqScore !== null &&
+          submission.requiredMCQScore &&
+          submission.requiredMCQScore > 0
+        ) {
+          quizPercentage =
+            (submission.mcqScore / submission.requiredMCQScore) * 100;
+        }
+
+        const attemptPoints = 5;
+
+        const bonusPoints = this.calculateQuizOnTimeBonusPoints(
+          submission.submittedAt,
+          submission.deadline,
+        );
+
+        const scorePoints = this.calculateQuizScorePoints(quizPercentage);
+
+        const totalQuizPoints = attemptPoints + bonusPoints + scorePoints;
+
+        const existingPoints = chapterPointsMap.get(submission.chapterId) ?? 0;
+        chapterPointsMap.set(
+          submission.chapterId,
+          existingPoints + totalQuizPoints,
+        );
+      }
+    }
+
+    // Topic 5: Assignment
+    const assignmentChapterIds = chapters
+      .filter((chapter) => chapter.topicId === 5 && chapter.chapterId != null)
+      .map((chapter) => chapter.chapterId as number);
+
+    if (assignmentChapterIds.length > 0) {
+      const assignmentSubmissions = await db
+        .select({
+          chapterId: zuvyAssignmentSubmission.chapterId,
+          createdAt: zuvyAssignmentSubmission.createdAt,
+          timeLimit: zuvyAssignmentSubmission.timeLimit,
+        })
+        .from(zuvyAssignmentSubmission)
+        .where(
+          and(
+            eq(zuvyAssignmentSubmission.userId, userId),
+            eq(zuvyAssignmentSubmission.bootcampId, bootcampId),
+            inArray(zuvyAssignmentSubmission.chapterId, assignmentChapterIds),
+          ),
+        );
+
+      for (const submission of assignmentSubmissions) {
+        if (submission.chapterId == null) {
+          continue;
+        }
+        const attemptPoints = 5;
+        const bonusPoints = this.calculateOnTimeBonusPoints(
+          submission.createdAt,
+          submission.timeLimit,
+        );
+        const totalPoints = attemptPoints + bonusPoints;
+
+        const existingPoints = chapterPointsMap.get(submission.chapterId) ?? 0;
+        chapterPointsMap.set(
+          submission.chapterId,
+          existingPoints + totalPoints,
+        );
+      }
+    }
+
+    // Topic 6: Assessment
+    const assessmentChapterIds = chapters
+      .filter((chapter) => chapter.topicId === 6 && chapter.chapterId != null)
+      .map((chapter) => chapter.chapterId as number);
+
+    if (assessmentChapterIds.length > 0) {
+      const assessmentSubmissions = await db
+        .select({
+          chapterId: zuvyOutsourseAssessments.chapterId,
+          percentage: zuvyAssessmentSubmission.percentage,
+          submittedAt: zuvyAssessmentSubmission.submitedAt,
+          deadline: zuvyOutsourseAssessments.deadline,
+        })
+        .from(zuvyAssessmentSubmission)
+        .leftJoin(
+          zuvyOutsourseAssessments,
+          eq(
+            zuvyAssessmentSubmission.assessmentOutsourseId,
+            zuvyOutsourseAssessments.id,
+          ),
+        )
+        .where(
+          and(
+            eq(zuvyAssessmentSubmission.userId, userId),
+            eq(zuvyOutsourseAssessments.bootcampId, bootcampId),
+            inArray(zuvyOutsourseAssessments.chapterId, assessmentChapterIds),
+          ),
+        );
+
+      for (const submission of assessmentSubmissions) {
+        if (submission.chapterId == null) {
+          continue;
+        }
+        const pointsBreakdown = this.calculateTotalAssessmentPoints(
+          submission.percentage || 0,
+          submission.submittedAt,
+          submission.deadline,
+        );
+
+        const existingPoints = chapterPointsMap.get(submission.chapterId) ?? 0;
+        chapterPointsMap.set(
+          submission.chapterId,
+          existingPoints + pointsBreakdown.totalPoints,
+        );
+      }
+    }
+
+    // Topic 8: Recording
+    const recordingChapterIds = chapters
+      .filter((chapter) => chapter.topicId === 8 && chapter.chapterId != null)
+      .map((chapter) => chapter.chapterId as number);
+
+    if (recordingChapterIds.length > 0) {
+      const recordingCompletions = await db
+        .select({
+          chapterId: zuvyChapterTracking.chapterId,
+        })
+        .from(zuvyChapterTracking)
+        .where(
+          and(
+            eq(zuvyChapterTracking.userId, BigInt(userId)),
+            inArray(zuvyChapterTracking.chapterId, recordingChapterIds),
+            isNotNull(zuvyChapterTracking.completedAt),
+          ),
+        );
+
+      for (const recording of recordingCompletions) {
+        if (recording.chapterId != null) {
+          chapterPointsMap.set(recording.chapterId, 5);
+        }
+      }
+    }
+
+    return chapterPointsMap;
   }
 
   async updateLeaderboard(): Promise<{
@@ -1222,7 +1632,10 @@ export class LeaderboardService {
           .where(eq(zuvyBatchEnrollments.bootcampId, bootcampId))
           .orderBy(sql`COALESCE(${zuvyLearnerLeaderboard.totalPoints}, 0) DESC`)
           .limit(limit);
-        return leaderboard;
+        return leaderboard.map((row) => ({
+          ...row,
+          learnerId: Number(row.learnerId),
+        }));
       } else {
         const leaderboard = await db
           .select({
@@ -1300,7 +1713,7 @@ export class LeaderboardService {
         )
         .where(
           and(
-            eq(zuvyBatchEnrollments.userId, learnerId),
+            eq(zuvyBatchEnrollments.userId, BigInt(learnerId)),
             eq(zuvyBatchEnrollments.bootcampId, bootcampId),
           ),
         )
@@ -1338,7 +1751,7 @@ export class LeaderboardService {
   }
 
   private calculateCodingAttemptPoints(): number {
-    return 5;
+    return 10;
   }
 
   private calculateCodingOnTimeBonusPoints(
@@ -1430,7 +1843,7 @@ export class LeaderboardService {
         .from(zuvyBatchEnrollments)
         .where(
           and(
-            eq(zuvyBatchEnrollments.userId, normalizedLearnerId),
+            eq(zuvyBatchEnrollments.userId, BigInt(normalizedLearnerId)),
             eq(zuvyBatchEnrollments.bootcampId, bootcampId),
           ),
         )

--- a/src/controller/leaderboard/leaderboard.service.ts
+++ b/src/controller/leaderboard/leaderboard.service.ts
@@ -1135,12 +1135,20 @@ export class LeaderboardService {
     if (codingChapterIds.length > 0) {
       const codingSubmissions = await db
         .select({
-          chapterId: zuvyOutsourseCodingQuestions.chapterId,
+          chapterId: zuvyPracticeCode.chapterId,
           submittedAt: zuvyPracticeCode.createdAt,
           deadline: zuvyOutsourseAssessments.deadline,
           practiceCodeId: zuvyPracticeCode.id,
         })
         .from(zuvyPracticeCode)
+        .innerJoin(
+          zuvyModuleChapter,
+          eq(zuvyPracticeCode.chapterId, zuvyModuleChapter.id),
+        )
+        .innerJoin(
+          zuvyCourseModules,
+          eq(zuvyModuleChapter.moduleId, zuvyCourseModules.id),
+        )
         .leftJoin(
           zuvyOutsourseCodingQuestions,
           eq(
@@ -1158,8 +1166,8 @@ export class LeaderboardService {
         .where(
           and(
             eq(zuvyPracticeCode.userId, BigInt(userId)),
-            eq(zuvyOutsourseCodingQuestions.bootcampId, bootcampId),
-            inArray(zuvyOutsourseCodingQuestions.chapterId, codingChapterIds),
+            eq(zuvyCourseModules.bootcampId, bootcampId),
+            inArray(zuvyPracticeCode.chapterId, codingChapterIds),
           ),
         );
 
@@ -1182,6 +1190,8 @@ export class LeaderboardService {
           failedTestCases.map((tc) => tc.submissionId),
         );
 
+        const chapterMaxPoints = new Map<number, number>();
+
         for (const submission of codingSubmissions) {
           if (submission.chapterId == null) {
             continue;
@@ -1196,12 +1206,49 @@ export class LeaderboardService {
             allTestCasesPassed,
           );
 
-          const existingPoints =
-            chapterPointsMap.get(submission.chapterId) ?? 0;
-          chapterPointsMap.set(
-            submission.chapterId,
-            existingPoints + pointsBreakdown.totalCodingPoints,
-          );
+          const existingMax = chapterMaxPoints.get(submission.chapterId) ?? 0;
+          if (pointsBreakdown.totalCodingPoints > existingMax) {
+            chapterMaxPoints.set(
+              submission.chapterId,
+              pointsBreakdown.totalCodingPoints,
+            );
+          }
+        }
+
+        for (const [chapterId, points] of chapterMaxPoints.entries()) {
+          const existingPoints = chapterPointsMap.get(chapterId) ?? 0;
+          chapterPointsMap.set(chapterId, existingPoints + points);
+        }
+      }
+
+      const codingCompletions = await db
+        .select({
+          chapterId: zuvyChapterTracking.chapterId,
+        })
+        .from(zuvyChapterTracking)
+        .innerJoin(
+          zuvyModuleChapter,
+          eq(zuvyChapterTracking.chapterId, zuvyModuleChapter.id),
+        )
+        .innerJoin(
+          zuvyCourseModules,
+          eq(zuvyModuleChapter.moduleId, zuvyCourseModules.id),
+        )
+        .where(
+          and(
+            eq(zuvyChapterTracking.userId, BigInt(userId)),
+            eq(zuvyCourseModules.bootcampId, bootcampId),
+            eq(zuvyModuleChapter.topicId, 3),
+            inArray(zuvyChapterTracking.chapterId, codingChapterIds),
+          ),
+        );
+
+      for (const completion of codingCompletions) {
+        if (completion.chapterId != null) {
+          const currentPoints = chapterPointsMap.get(completion.chapterId) ?? 0;
+          if (currentPoints < 5) {
+            chapterPointsMap.set(completion.chapterId, 5);
+          }
         }
       }
     }
@@ -1236,7 +1283,7 @@ export class LeaderboardService {
 
       for (const quiz of quizCompletions) {
         if (quiz.chapterId != null) {
-          chapterPointsMap.set(quiz.chapterId, 10);
+          chapterPointsMap.set(quiz.chapterId, 5);
         }
       }
     }

--- a/src/controller/leaderboard/leaderboard.service.ts
+++ b/src/controller/leaderboard/leaderboard.service.ts
@@ -348,12 +348,28 @@ export class LeaderboardService {
         )
         .where(sql`${zuvyOutsourseQuizzes.bootcampId} IS NOT NULL`);
 
-      if (quizSubmissions.length === 0) {
-        this.logger.log('No quiz submissions found');
-        return new Map();
-      }
-
-      this.logger.log(`Found ${quizSubmissions.length} quiz submissions`);
+      const standaloneQuizCompletions = await db
+        .select({
+          userId: zuvyChapterTracking.userId,
+          chapterId: zuvyChapterTracking.chapterId,
+          bootcampId: zuvyCourseModules.bootcampId,
+          completedAt: zuvyChapterTracking.completedAt,
+        })
+        .from(zuvyChapterTracking)
+        .leftJoin(
+          zuvyModuleChapter,
+          eq(zuvyChapterTracking.chapterId, zuvyModuleChapter.id),
+        )
+        .leftJoin(
+          zuvyCourseModules,
+          eq(zuvyModuleChapter.moduleId, zuvyCourseModules.id),
+        )
+        .where(
+          and(
+            eq(zuvyModuleChapter.topicId, 4),
+            sql`${zuvyCourseModules.bootcampId} IS NOT NULL`,
+          ),
+        );
 
       const quizMap = new Map<
         string,
@@ -363,6 +379,18 @@ export class LeaderboardService {
           lastActivityAt: string;
         }
       >();
+
+      if (
+        quizSubmissions.length === 0 &&
+        standaloneQuizCompletions.length === 0
+      ) {
+        this.logger.log('No quiz submissions or completions found');
+        return quizMap;
+      }
+
+      this.logger.log(
+        `Found ${quizSubmissions.length} quiz submissions and ${standaloneQuizCompletions.length} standalone completions`,
+      );
 
       for (const submission of quizSubmissions) {
         if (!submission.userId || !submission.bootcampId) {
@@ -405,8 +433,54 @@ export class LeaderboardService {
         quizMap.set(key, entry);
       }
 
+      const completionsByLearnerBootcamp = new Map<string, Set<number>>();
+
+      for (const completion of standaloneQuizCompletions) {
+        if (
+          !completion.userId ||
+          !completion.bootcampId ||
+          !completion.chapterId
+        ) {
+          continue;
+        }
+
+        const key = `${completion.userId}-${completion.bootcampId}`;
+
+        if (!completionsByLearnerBootcamp.has(key)) {
+          completionsByLearnerBootcamp.set(key, new Set());
+        }
+
+        completionsByLearnerBootcamp.get(key)!.add(completion.chapterId);
+
+        const entry = quizMap.get(key) || {
+          chapterPoints: new Map<number, number>(),
+          quizPoints: 0,
+          lastActivityAt: completion.completedAt || new Date().toISOString(),
+        };
+
+        if (completion.completedAt) {
+          const compTime = new Date(completion.completedAt).getTime();
+          const entryTime = new Date(entry.lastActivityAt).getTime();
+          if (compTime > entryTime) {
+            entry.lastActivityAt = completion.completedAt;
+          }
+        }
+
+        quizMap.set(key, entry);
+      }
+
+      for (const [key, chapterSet] of completionsByLearnerBootcamp.entries()) {
+        const entry = quizMap.get(key);
+        if (entry) {
+          for (const chapterId of chapterSet) {
+            entry.chapterPoints.set(chapterId, 5);
+          }
+          entry.quizPoints += chapterSet.size * 5;
+        }
+      }
+
       this.logger.log(
-        `Processed quiz submissions for ${quizMap.size} learner-bootcamp combinations`,
+        `Processed quiz points for ${quizMap.size} learner-bootcamp combinations`,
       );
       return quizMap;
     } catch (error) {
@@ -1048,7 +1122,7 @@ export class LeaderboardService {
 
       for (const article of articleCompletions) {
         if (article.chapterId != null) {
-          chapterPointsMap.set(article.chapterId, 5);
+          chapterPointsMap.set(article.chapterId, 10);
         }
       }
     }
@@ -1138,74 +1212,32 @@ export class LeaderboardService {
       .map((chapter) => chapter.chapterId as number);
 
     if (quizChapterIds.length > 0) {
-      const quizSubmissions = await db
+      const quizCompletions = await db
         .select({
-          chapterId: zuvyOutsourseQuizzes.chapterId,
-          mcqScore: zuvyAssessmentSubmission.mcqScore,
-          requiredMCQScore: zuvyAssessmentSubmission.requiredMCQScore,
-          submittedAt: zuvyAssessmentSubmission.submitedAt,
-          deadline: zuvyOutsourseAssessments.deadline,
-          createdAt: zuvyQuizTracking.createdAt,
+          chapterId: zuvyChapterTracking.chapterId,
         })
-        .from(zuvyQuizTracking)
-        .leftJoin(
-          zuvyAssessmentSubmission,
-          eq(
-            zuvyQuizTracking.assessmentSubmissionId,
-            zuvyAssessmentSubmission.id,
-          ),
+        .from(zuvyChapterTracking)
+        .innerJoin(
+          zuvyModuleChapter,
+          eq(zuvyChapterTracking.chapterId, zuvyModuleChapter.id),
         )
-        .leftJoin(
-          zuvyOutsourseQuizzes,
-          eq(zuvyQuizTracking.questionId, zuvyOutsourseQuizzes.id),
-        )
-        .leftJoin(
-          zuvyOutsourseAssessments,
-          eq(
-            zuvyOutsourseQuizzes.assessmentOutsourseId,
-            zuvyOutsourseAssessments.id,
-          ),
+        .innerJoin(
+          zuvyCourseModules,
+          eq(zuvyModuleChapter.moduleId, zuvyCourseModules.id),
         )
         .where(
           and(
-            eq(zuvyQuizTracking.userId, userId),
-            eq(zuvyOutsourseQuizzes.bootcampId, bootcampId),
-            inArray(zuvyOutsourseQuizzes.chapterId, quizChapterIds),
+            eq(zuvyChapterTracking.userId, BigInt(userId)),
+            eq(zuvyCourseModules.bootcampId, bootcampId),
+            eq(zuvyModuleChapter.topicId, 4),
+            inArray(zuvyChapterTracking.chapterId, quizChapterIds),
           ),
         );
 
-      for (const submission of quizSubmissions) {
-        if (submission.chapterId == null) {
-          continue;
+      for (const quiz of quizCompletions) {
+        if (quiz.chapterId != null) {
+          chapterPointsMap.set(quiz.chapterId, 5);
         }
-
-        let quizPercentage = 0;
-
-        if (
-          submission.mcqScore !== null &&
-          submission.requiredMCQScore &&
-          submission.requiredMCQScore > 0
-        ) {
-          quizPercentage =
-            (submission.mcqScore / submission.requiredMCQScore) * 100;
-        }
-
-        const attemptPoints = 5;
-
-        const bonusPoints = this.calculateQuizOnTimeBonusPoints(
-          submission.submittedAt,
-          submission.deadline,
-        );
-
-        const scorePoints = this.calculateQuizScorePoints(quizPercentage);
-
-        const totalQuizPoints = attemptPoints + bonusPoints + scorePoints;
-
-        const existingPoints = chapterPointsMap.get(submission.chapterId) ?? 0;
-        chapterPointsMap.set(
-          submission.chapterId,
-          existingPoints + totalQuizPoints,
-        );
       }
     }
 

--- a/src/controller/leaderboard/leaderboard.service.ts
+++ b/src/controller/leaderboard/leaderboard.service.ts
@@ -238,6 +238,32 @@ export class LeaderboardService {
         return codingMap;
       }
 
+      const practiceCodeIds = codingSubmissions
+        .map((s) => s.practiceCodeId)
+        .filter((id): id is number => id != null);
+
+      const failedTestCases =
+        practiceCodeIds.length > 0
+          ? await db
+              .select({
+                submissionId: zuvyTestCasesSubmission.submissionId,
+              })
+              .from(zuvyTestCasesSubmission)
+              .where(
+                and(
+                  inArray(
+                    zuvyTestCasesSubmission.submissionId,
+                    practiceCodeIds,
+                  ),
+                  sql`${zuvyTestCasesSubmission.status} != 'Accepted'`,
+                ),
+              )
+          : [];
+
+      const failedSubmissionIdsSet = new Set(
+        failedTestCases.map((tc) => tc.submissionId),
+      );
+
       for (const submission of codingSubmissions) {
         if (
           !submission.userId ||
@@ -247,20 +273,9 @@ export class LeaderboardService {
           continue;
         }
 
-        const failedTestCases = await db
-          .select()
-          .from(zuvyTestCasesSubmission)
-          .where(
-            and(
-              eq(
-                zuvyTestCasesSubmission.submissionId,
-                submission.practiceCodeId,
-              ),
-              sql`${zuvyTestCasesSubmission.status} != 'Accepted'`,
-            ),
-          );
-
-        const allTestCasesPassed = failedTestCases.length === 0;
+        const allTestCasesPassed = !failedSubmissionIdsSet.has(
+          submission.practiceCodeId,
+        );
 
         const pointsBreakdown = this.calculateTotalCodingPoints(
           submission.submittedAt,
@@ -1057,367 +1072,354 @@ export class LeaderboardService {
       }
     }
 
-    // Topic 1: Video (working; don't break)
+    // Filter chapter IDs by topic
     const videoChapterIds = chapters
       .filter((chapter) => chapter.topicId === 1 && chapter.chapterId != null)
       .map((chapter) => chapter.chapterId as number);
 
-    if (videoChapterIds.length > 0) {
-      const videoCompletions = await db
-        .select({
-          chapterId: zuvyChapterTracking.chapterId,
-        })
-        .from(zuvyChapterTracking)
-        .innerJoin(
-          zuvyModuleChapter,
-          eq(zuvyChapterTracking.chapterId, zuvyModuleChapter.id),
-        )
-        .innerJoin(
-          zuvyCourseModules,
-          eq(zuvyModuleChapter.moduleId, zuvyCourseModules.id),
-        )
-        .where(
-          and(
-            eq(zuvyChapterTracking.userId, BigInt(userId)),
-            eq(zuvyCourseModules.bootcampId, bootcampId),
-            eq(zuvyModuleChapter.topicId, 1),
-            inArray(zuvyChapterTracking.chapterId, videoChapterIds),
-          ),
-        );
-
-      for (const video of videoCompletions) {
-        if (video.chapterId != null) {
-          chapterPointsMap.set(video.chapterId, 10);
-        }
-      }
-    }
-
-    // Topic 2: Article (working; don't break)
     const articleChapterIds = chapters
       .filter((chapter) => chapter.topicId === 2 && chapter.chapterId != null)
       .map((chapter) => chapter.chapterId as number);
 
-    if (articleChapterIds.length > 0) {
-      const articleCompletions = await db
-        .select({
-          chapterId: zuvyChapterTracking.chapterId,
-        })
-        .from(zuvyChapterTracking)
-        .innerJoin(
-          zuvyModuleChapter,
-          eq(zuvyChapterTracking.chapterId, zuvyModuleChapter.id),
-        )
-        .innerJoin(
-          zuvyCourseModules,
-          eq(zuvyModuleChapter.moduleId, zuvyCourseModules.id),
-        )
-        .where(
-          and(
-            eq(zuvyChapterTracking.userId, BigInt(userId)),
-            eq(zuvyCourseModules.bootcampId, bootcampId),
-            eq(zuvyModuleChapter.topicId, 2),
-            inArray(zuvyChapterTracking.chapterId, articleChapterIds),
-          ),
-        );
-
-      for (const article of articleCompletions) {
-        if (article.chapterId != null) {
-          chapterPointsMap.set(article.chapterId, 10);
-        }
-      }
-    }
-
-    // Topic 3: Coding
     const codingChapterIds = chapters
       .filter((chapter) => chapter.topicId === 3 && chapter.chapterId != null)
       .map((chapter) => chapter.chapterId as number);
 
-    if (codingChapterIds.length > 0) {
-      const codingSubmissions = await db
-        .select({
-          chapterId: zuvyPracticeCode.chapterId,
-          submittedAt: zuvyPracticeCode.createdAt,
-          deadline: zuvyOutsourseAssessments.deadline,
-          practiceCodeId: zuvyPracticeCode.id,
-        })
-        .from(zuvyPracticeCode)
-        .innerJoin(
-          zuvyModuleChapter,
-          eq(zuvyPracticeCode.chapterId, zuvyModuleChapter.id),
-        )
-        .innerJoin(
-          zuvyCourseModules,
-          eq(zuvyModuleChapter.moduleId, zuvyCourseModules.id),
-        )
-        .leftJoin(
-          zuvyOutsourseCodingQuestions,
-          eq(
-            zuvyPracticeCode.codingOutsourseId,
-            zuvyOutsourseCodingQuestions.id,
-          ),
-        )
-        .leftJoin(
-          zuvyOutsourseAssessments,
-          eq(
-            zuvyOutsourseCodingQuestions.assessmentOutsourseId,
-            zuvyOutsourseAssessments.id,
-          ),
-        )
-        .where(
-          and(
-            eq(zuvyPracticeCode.userId, BigInt(userId)),
-            eq(zuvyCourseModules.bootcampId, bootcampId),
-            inArray(zuvyPracticeCode.chapterId, codingChapterIds),
-          ),
-        );
-
-      if (codingSubmissions.length > 0) {
-        const practiceCodeIds = codingSubmissions.map((s) => s.practiceCodeId);
-
-        const failedTestCases = await db
-          .select({
-            submissionId: zuvyTestCasesSubmission.submissionId,
-          })
-          .from(zuvyTestCasesSubmission)
-          .where(
-            and(
-              inArray(zuvyTestCasesSubmission.submissionId, practiceCodeIds),
-              sql`${zuvyTestCasesSubmission.status} != 'Accepted'`,
-            ),
-          );
-
-        const failedSubmissionIdsSet = new Set(
-          failedTestCases.map((tc) => tc.submissionId),
-        );
-
-        const chapterMaxPoints = new Map<number, number>();
-
-        for (const submission of codingSubmissions) {
-          if (submission.chapterId == null) {
-            continue;
-          }
-          const allTestCasesPassed = !failedSubmissionIdsSet.has(
-            submission.practiceCodeId,
-          );
-
-          const pointsBreakdown = this.calculateTotalCodingPoints(
-            submission.submittedAt,
-            submission.deadline,
-            allTestCasesPassed,
-          );
-
-          const existingMax = chapterMaxPoints.get(submission.chapterId) ?? 0;
-          if (pointsBreakdown.totalCodingPoints > existingMax) {
-            chapterMaxPoints.set(
-              submission.chapterId,
-              pointsBreakdown.totalCodingPoints,
-            );
-          }
-        }
-
-        for (const [chapterId, points] of chapterMaxPoints.entries()) {
-          const existingPoints = chapterPointsMap.get(chapterId) ?? 0;
-          chapterPointsMap.set(chapterId, existingPoints + points);
-        }
-      }
-
-      const codingCompletions = await db
-        .select({
-          chapterId: zuvyChapterTracking.chapterId,
-        })
-        .from(zuvyChapterTracking)
-        .innerJoin(
-          zuvyModuleChapter,
-          eq(zuvyChapterTracking.chapterId, zuvyModuleChapter.id),
-        )
-        .innerJoin(
-          zuvyCourseModules,
-          eq(zuvyModuleChapter.moduleId, zuvyCourseModules.id),
-        )
-        .where(
-          and(
-            eq(zuvyChapterTracking.userId, BigInt(userId)),
-            eq(zuvyCourseModules.bootcampId, bootcampId),
-            eq(zuvyModuleChapter.topicId, 3),
-            inArray(zuvyChapterTracking.chapterId, codingChapterIds),
-          ),
-        );
-
-      for (const completion of codingCompletions) {
-        if (completion.chapterId != null) {
-          const currentPoints = chapterPointsMap.get(completion.chapterId) ?? 0;
-          if (currentPoints < 5) {
-            chapterPointsMap.set(completion.chapterId, 5);
-          }
-        }
-      }
-    }
-
-    // Topic 4: Quiz
     const quizChapterIds = chapters
       .filter((chapter) => chapter.topicId === 4 && chapter.chapterId != null)
       .map((chapter) => chapter.chapterId as number);
 
-    if (quizChapterIds.length > 0) {
-      const quizCompletions = await db
-        .select({
-          chapterId: zuvyChapterTracking.chapterId,
-        })
-        .from(zuvyChapterTracking)
-        .innerJoin(
-          zuvyModuleChapter,
-          eq(zuvyChapterTracking.chapterId, zuvyModuleChapter.id),
-        )
-        .innerJoin(
-          zuvyCourseModules,
-          eq(zuvyModuleChapter.moduleId, zuvyCourseModules.id),
-        )
-        .where(
-          and(
-            eq(zuvyChapterTracking.userId, BigInt(userId)),
-            eq(zuvyCourseModules.bootcampId, bootcampId),
-            eq(zuvyModuleChapter.topicId, 4),
-            inArray(zuvyChapterTracking.chapterId, quizChapterIds),
-          ),
-        );
-
-      for (const quiz of quizCompletions) {
-        if (quiz.chapterId != null) {
-          chapterPointsMap.set(quiz.chapterId, 5);
-        }
-      }
-    }
-
-    // Topic 5: Assignment
     const assignmentChapterIds = chapters
       .filter((chapter) => chapter.topicId === 5 && chapter.chapterId != null)
       .map((chapter) => chapter.chapterId as number);
 
-    if (assignmentChapterIds.length > 0) {
-      const assignmentSubmissions = await db
-        .select({
-          chapterId: zuvyAssignmentSubmission.chapterId,
-          createdAt: zuvyAssignmentSubmission.createdAt,
-          timeLimit: zuvyAssignmentSubmission.timeLimit,
-        })
-        .from(zuvyAssignmentSubmission)
-        .where(
-          and(
-            eq(zuvyAssignmentSubmission.userId, userId),
-            eq(zuvyAssignmentSubmission.bootcampId, bootcampId),
-            inArray(zuvyAssignmentSubmission.chapterId, assignmentChapterIds),
-          ),
-        );
-
-      for (const submission of assignmentSubmissions) {
-        if (submission.chapterId == null) {
-          continue;
-        }
-
-        const attemptPoints = 5;
-
-        const submittedSecond = submission.createdAt
-          ? Math.floor(new Date(submission.createdAt).getTime() / 1000)
-          : null;
-
-        const deadlineSecond = submission.timeLimit
-          ? Math.floor(new Date(submission.timeLimit).getTime() / 1000)
-          : null;
-
-        const bonusPoints =
-          submittedSecond !== null &&
-          deadlineSecond !== null &&
-          submittedSecond <= deadlineSecond
-            ? 5
-            : 0;
-
-        const totalPoints = attemptPoints + bonusPoints;
-
-        const existingPoints = chapterPointsMap.get(submission.chapterId) ?? 0;
-
-        chapterPointsMap.set(
-          submission.chapterId,
-          existingPoints + totalPoints,
-        );
-
-        assignmentBreakdownMap.set(submission.chapterId, {
-          assignment: attemptPoints,
-          bonus: bonusPoints,
-          performance: 0,
-        });
-      }
-    }
-
-    // Topic 6: Assessment
     const assessmentChapterIds = chapters
       .filter((chapter) => chapter.topicId === 6 && chapter.chapterId != null)
       .map((chapter) => chapter.chapterId as number);
 
-    if (assessmentChapterIds.length > 0) {
-      const assessmentSubmissions = await db
-        .select({
-          chapterId: zuvyOutsourseAssessments.chapterId,
-          percentage: zuvyAssessmentSubmission.percentage,
-          submittedAt: zuvyAssessmentSubmission.submitedAt,
-          deadline: zuvyOutsourseAssessments.deadline,
-        })
-        .from(zuvyAssessmentSubmission)
-        .leftJoin(
-          zuvyOutsourseAssessments,
-          eq(
-            zuvyAssessmentSubmission.assessmentOutsourseId,
-            zuvyOutsourseAssessments.id,
-          ),
-        )
-        .where(
-          and(
-            eq(zuvyAssessmentSubmission.userId, userId),
-            eq(zuvyOutsourseAssessments.bootcampId, bootcampId),
-            inArray(zuvyOutsourseAssessments.chapterId, assessmentChapterIds),
-          ),
-        );
-
-      for (const submission of assessmentSubmissions) {
-        if (submission.chapterId == null) {
-          continue;
-        }
-        const pointsBreakdown = this.calculateTotalAssessmentPoints(
-          submission.percentage || 0,
-          submission.submittedAt,
-          submission.deadline,
-        );
-
-        const existingPoints = chapterPointsMap.get(submission.chapterId) ?? 0;
-        chapterPointsMap.set(
-          submission.chapterId,
-          existingPoints + pointsBreakdown.totalPoints,
-        );
-      }
-    }
-
-    // Topic 8: Recording
     const recordingChapterIds = chapters
       .filter((chapter) => chapter.topicId === 8 && chapter.chapterId != null)
       .map((chapter) => chapter.chapterId as number);
 
-    if (recordingChapterIds.length > 0) {
-      const recordingCompletions = await db
+    // 3. Define parallel database queries
+    const videoPromise =
+      videoChapterIds.length > 0
+        ? db
+            .select({
+              chapterId: zuvyChapterTracking.chapterId,
+            })
+            .from(zuvyChapterTracking)
+            .where(
+              and(
+                eq(zuvyChapterTracking.userId, BigInt(userId)),
+                inArray(zuvyChapterTracking.chapterId, videoChapterIds),
+              ),
+            )
+        : Promise.resolve([]);
+
+    const articlePromise =
+      articleChapterIds.length > 0
+        ? db
+            .select({
+              chapterId: zuvyChapterTracking.chapterId,
+            })
+            .from(zuvyChapterTracking)
+            .where(
+              and(
+                eq(zuvyChapterTracking.userId, BigInt(userId)),
+                inArray(zuvyChapterTracking.chapterId, articleChapterIds),
+              ),
+            )
+        : Promise.resolve([]);
+
+    const codingPromise =
+      codingChapterIds.length > 0
+        ? db
+            .select({
+              chapterId: zuvyPracticeCode.chapterId,
+              submittedAt: zuvyPracticeCode.createdAt,
+              deadline: zuvyOutsourseAssessments.deadline,
+              practiceCodeId: zuvyPracticeCode.id,
+            })
+            .from(zuvyPracticeCode)
+            .leftJoin(
+              zuvyOutsourseCodingQuestions,
+              eq(
+                zuvyPracticeCode.codingOutsourseId,
+                zuvyOutsourseCodingQuestions.id,
+              ),
+            )
+            .leftJoin(
+              zuvyOutsourseAssessments,
+              eq(
+                zuvyOutsourseCodingQuestions.assessmentOutsourseId,
+                zuvyOutsourseAssessments.id,
+              ),
+            )
+            .where(
+              and(
+                eq(zuvyPracticeCode.userId, BigInt(userId)),
+                inArray(zuvyPracticeCode.chapterId, codingChapterIds),
+              ),
+            )
+        : Promise.resolve([]);
+
+    const codingCompletionsPromise =
+      codingChapterIds.length > 0
+        ? db
+            .select({
+              chapterId: zuvyChapterTracking.chapterId,
+            })
+            .from(zuvyChapterTracking)
+            .where(
+              and(
+                eq(zuvyChapterTracking.userId, BigInt(userId)),
+                inArray(zuvyChapterTracking.chapterId, codingChapterIds),
+              ),
+            )
+        : Promise.resolve([]);
+
+    const quizPromise =
+      quizChapterIds.length > 0
+        ? db
+            .select({
+              chapterId: zuvyChapterTracking.chapterId,
+            })
+            .from(zuvyChapterTracking)
+            .where(
+              and(
+                eq(zuvyChapterTracking.userId, BigInt(userId)),
+                inArray(zuvyChapterTracking.chapterId, quizChapterIds),
+              ),
+            )
+        : Promise.resolve([]);
+
+    const assignmentPromise =
+      assignmentChapterIds.length > 0
+        ? db
+            .select({
+              chapterId: zuvyAssignmentSubmission.chapterId,
+              createdAt: zuvyAssignmentSubmission.createdAt,
+              timeLimit: zuvyAssignmentSubmission.timeLimit,
+            })
+            .from(zuvyAssignmentSubmission)
+            .where(
+              and(
+                eq(zuvyAssignmentSubmission.userId, userId),
+                eq(zuvyAssignmentSubmission.bootcampId, bootcampId),
+                inArray(
+                  zuvyAssignmentSubmission.chapterId,
+                  assignmentChapterIds,
+                ),
+              ),
+            )
+        : Promise.resolve([]);
+
+    const assessmentPromise =
+      assessmentChapterIds.length > 0
+        ? db
+            .select({
+              chapterId: zuvyOutsourseAssessments.chapterId,
+              percentage: zuvyAssessmentSubmission.percentage,
+              submittedAt: zuvyAssessmentSubmission.submitedAt,
+              deadline: zuvyOutsourseAssessments.deadline,
+            })
+            .from(zuvyAssessmentSubmission)
+            .leftJoin(
+              zuvyOutsourseAssessments,
+              eq(
+                zuvyAssessmentSubmission.assessmentOutsourseId,
+                zuvyOutsourseAssessments.id,
+              ),
+            )
+            .where(
+              and(
+                eq(zuvyAssessmentSubmission.userId, userId),
+                eq(zuvyOutsourseAssessments.bootcampId, bootcampId),
+                inArray(
+                  zuvyOutsourseAssessments.chapterId,
+                  assessmentChapterIds,
+                ),
+              ),
+            )
+        : Promise.resolve([]);
+
+    const recordingPromise =
+      recordingChapterIds.length > 0
+        ? db
+            .select({
+              chapterId: zuvyChapterTracking.chapterId,
+            })
+            .from(zuvyChapterTracking)
+            .where(
+              and(
+                eq(zuvyChapterTracking.userId, BigInt(userId)),
+                inArray(zuvyChapterTracking.chapterId, recordingChapterIds),
+                isNotNull(zuvyChapterTracking.completedAt),
+              ),
+            )
+        : Promise.resolve([]);
+
+    // 4. Run parallel queries
+    const [
+      videoCompletions,
+      articleCompletions,
+      codingSubmissions,
+      codingCompletions,
+      quizCompletions,
+      assignmentSubmissions,
+      assessmentSubmissions,
+      recordingCompletions,
+    ] = await Promise.all([
+      videoPromise,
+      articlePromise,
+      codingPromise,
+      codingCompletionsPromise,
+      quizPromise,
+      assignmentPromise,
+      assessmentPromise,
+      recordingPromise,
+    ]);
+
+    // 5. Process video results
+    for (const video of videoCompletions) {
+      if (video.chapterId != null) {
+        chapterPointsMap.set(video.chapterId, 10);
+      }
+    }
+
+    // 6. Process article results
+    for (const article of articleCompletions) {
+      if (article.chapterId != null) {
+        chapterPointsMap.set(article.chapterId, 10);
+      }
+    }
+
+    // 7. Process coding results
+    if (codingSubmissions.length > 0) {
+      const practiceCodeIds = codingSubmissions.map((s) => s.practiceCodeId);
+
+      const failedTestCases = await db
         .select({
-          chapterId: zuvyChapterTracking.chapterId,
+          submissionId: zuvyTestCasesSubmission.submissionId,
         })
-        .from(zuvyChapterTracking)
+        .from(zuvyTestCasesSubmission)
         .where(
           and(
-            eq(zuvyChapterTracking.userId, BigInt(userId)),
-            inArray(zuvyChapterTracking.chapterId, recordingChapterIds),
-            isNotNull(zuvyChapterTracking.completedAt),
+            inArray(zuvyTestCasesSubmission.submissionId, practiceCodeIds),
+            sql`${zuvyTestCasesSubmission.status} != 'Accepted'`,
           ),
         );
 
-      for (const recording of recordingCompletions) {
-        if (recording.chapterId != null) {
-          chapterPointsMap.set(recording.chapterId, 5);
+      const failedSubmissionIdsSet = new Set(
+        failedTestCases.map((tc) => tc.submissionId),
+      );
+
+      const chapterMaxPoints = new Map<number, number>();
+
+      for (const submission of codingSubmissions) {
+        if (submission.chapterId == null) {
+          continue;
         }
+        const allTestCasesPassed = !failedSubmissionIdsSet.has(
+          submission.practiceCodeId,
+        );
+
+        const pointsBreakdown = this.calculateTotalCodingPoints(
+          submission.submittedAt,
+          submission.deadline,
+          allTestCasesPassed,
+        );
+
+        const existingMax = chapterMaxPoints.get(submission.chapterId) ?? 0;
+        if (pointsBreakdown.totalCodingPoints > existingMax) {
+          chapterMaxPoints.set(
+            submission.chapterId,
+            pointsBreakdown.totalCodingPoints,
+          );
+        }
+      }
+
+      for (const [chapterId, points] of chapterMaxPoints.entries()) {
+        const existingPoints = chapterPointsMap.get(chapterId) ?? 0;
+        chapterPointsMap.set(chapterId, existingPoints + points);
+      }
+    }
+
+    for (const completion of codingCompletions) {
+      if (completion.chapterId != null) {
+        const currentPoints = chapterPointsMap.get(completion.chapterId) ?? 0;
+        if (currentPoints < 5) {
+          chapterPointsMap.set(completion.chapterId, 5);
+        }
+      }
+    }
+
+    // 8. Process quiz results
+    for (const quiz of quizCompletions) {
+      if (quiz.chapterId != null) {
+        chapterPointsMap.set(quiz.chapterId, 5);
+      }
+    }
+
+    // 9. Process assignment results
+    for (const submission of assignmentSubmissions) {
+      if (submission.chapterId == null) {
+        continue;
+      }
+
+      const attemptPoints = 5;
+
+      const submittedSecond = submission.createdAt
+        ? Math.floor(new Date(submission.createdAt).getTime() / 1000)
+        : null;
+
+      const deadlineSecond = submission.timeLimit
+        ? Math.floor(new Date(submission.timeLimit).getTime() / 1000)
+        : null;
+
+      const bonusPoints =
+        submittedSecond !== null &&
+        deadlineSecond !== null &&
+        submittedSecond <= deadlineSecond
+          ? 5
+          : 0;
+
+      const totalPoints = attemptPoints + bonusPoints;
+
+      const existingPoints = chapterPointsMap.get(submission.chapterId) ?? 0;
+
+      chapterPointsMap.set(submission.chapterId, existingPoints + totalPoints);
+
+      assignmentBreakdownMap.set(submission.chapterId, {
+        assignment: attemptPoints,
+        bonus: bonusPoints,
+        performance: 0,
+      });
+    }
+
+    // 10. Process assessment results
+    for (const submission of assessmentSubmissions) {
+      if (submission.chapterId == null) {
+        continue;
+      }
+      const pointsBreakdown = this.calculateTotalAssessmentPoints(
+        submission.percentage || 0,
+        submission.submittedAt,
+        submission.deadline,
+      );
+
+      const existingPoints = chapterPointsMap.get(submission.chapterId) ?? 0;
+      chapterPointsMap.set(
+        submission.chapterId,
+        existingPoints + pointsBreakdown.totalPoints,
+      );
+    }
+
+    // 11. Process recording results
+    for (const recording of recordingCompletions) {
+      if (recording.chapterId != null) {
+        chapterPointsMap.set(recording.chapterId, 5);
       }
     }
 
@@ -1601,42 +1603,82 @@ export class LeaderboardService {
       }
 
       let updatedCount = 0;
+      const insertValues: any[] = [];
+      const updatePromises: any[] = [];
 
       for (const entry of leaderboardMap.values()) {
-        try {
-          const existing = existingEntryMap.get(
-            `${entry.learnerId}-${entry.bootcampId}`,
-          );
+        const existing = existingEntryMap.get(
+          `${entry.learnerId}-${entry.bootcampId}`,
+        );
 
-          if (existing) {
-            const assessmentEntry = assessmentMap.get(
-              `${entry.learnerId}-${entry.bootcampId}`,
-            );
-            const codingEntry = codingMap.get(
-              `${entry.learnerId}-${entry.bootcampId}`,
-            );
-            const quizEntry = quizMap.get(
-              `${entry.learnerId}-${entry.bootcampId}`,
-            );
-            const attendanceEntry = attendanceMap.get(
-              `${entry.learnerId}-${entry.bootcampId}`,
-            );
-            const recordingEntry = recordingMap.get(
-              `${entry.learnerId}-${entry.bootcampId}`,
-            );
-            const assignmentEntry = assignmentMap.get(
-              `${entry.learnerId}-${entry.bootcampId}`,
-            );
-            const videoEntry = videoMap.get(
-              `${entry.learnerId}-${entry.bootcampId}`,
-            );
-            const articleEntry = articleMap.get(
-              `${entry.learnerId}-${entry.bootcampId}`,
-            );
+        const assessmentEntry = assessmentMap.get(
+          `${entry.learnerId}-${entry.bootcampId}`,
+        );
+        const codingEntry = codingMap.get(
+          `${entry.learnerId}-${entry.bootcampId}`,
+        );
+        const quizEntry = quizMap.get(`${entry.learnerId}-${entry.bootcampId}`);
+        const attendanceEntry = attendanceMap.get(
+          `${entry.learnerId}-${entry.bootcampId}`,
+        );
+        const recordingEntry = recordingMap.get(
+          `${entry.learnerId}-${entry.bootcampId}`,
+        );
+        const assignmentEntry = assignmentMap.get(
+          `${entry.learnerId}-${entry.bootcampId}`,
+        );
+        const videoEntry = videoMap.get(
+          `${entry.learnerId}-${entry.bootcampId}`,
+        );
+        const articleEntry = articleMap.get(
+          `${entry.learnerId}-${entry.bootcampId}`,
+        );
 
+        if (existing) {
+          const newAssessmentPoints =
+            assessmentEntry?.assessmentPoints ?? existing.assessmentPoints;
+          const newCodingPoints =
+            codingEntry?.codingPoints ?? existing.codingPoints;
+          const newQuizPoints = quizEntry?.quizPoints ?? existing.quizPoints;
+          const newAttendancePoints =
+            attendanceEntry?.attendancePoints ?? existing.attendancePoints;
+          const newRecordingPoints =
+            recordingEntry?.recordingPoints ?? existing.recordingPoints;
+          const newAssignmentPoints =
+            assignmentEntry?.assignmentPoints ?? existing.assignmentPoints;
+          const newVideoPoints =
+            videoEntry?.videoPoints ?? existing.videoPoints;
+          const newArticlePoints =
+            articleEntry?.articlePoints ?? existing.articlePoints;
+
+          const totalPoints =
+            newAssessmentPoints +
+            newCodingPoints +
+            newQuizPoints +
+            newAttendancePoints +
+            newRecordingPoints +
+            newAssignmentPoints +
+            newVideoPoints +
+            newArticlePoints;
+
+          // Only update if something changed
+          const hasChanged =
+            existing.assessmentPoints !== newAssessmentPoints ||
+            existing.codingPoints !== newCodingPoints ||
+            existing.quizPoints !== newQuizPoints ||
+            existing.attendancePoints !== newAttendancePoints ||
+            existing.recordingPoints !== newRecordingPoints ||
+            existing.assignmentPoints !== newAssignmentPoints ||
+            existing.videoPoints !== newVideoPoints ||
+            existing.articlePoints !== newArticlePoints ||
+            existing.totalPoints !== totalPoints ||
+            existing.lastActivityAt !== entry.lastActivityAt;
+
+          if (hasChanged) {
             const updateData: any = {
               lastActivityAt: entry.lastActivityAt,
               updatedAt: new Date().toISOString(),
+              totalPoints,
             };
 
             if (assessmentEntry)
@@ -1653,73 +1695,69 @@ export class LeaderboardService {
             if (articleEntry)
               updateData.articlePoints = articleEntry.articlePoints;
 
-            const newAssessmentPoints =
-              assessmentEntry?.assessmentPoints ?? existing.assessmentPoints;
-            const newCodingPoints =
-              codingEntry?.codingPoints ?? existing.codingPoints;
-            const newQuizPoints = quizEntry?.quizPoints ?? existing.quizPoints;
-            const newAttendancePoints =
-              attendanceEntry?.attendancePoints ?? existing.attendancePoints;
-            const newRecordingPoints =
-              recordingEntry?.recordingPoints ?? existing.recordingPoints;
-            const newAssignmentPoints =
-              assignmentEntry?.assignmentPoints ?? existing.assignmentPoints;
-            const newVideoPoints =
-              videoEntry?.videoPoints ?? existing.videoPoints;
-            const newArticlePoints =
-              articleEntry?.articlePoints ?? existing.articlePoints;
-
-            updateData.totalPoints =
-              newAssessmentPoints +
-              newCodingPoints +
-              newQuizPoints +
-              newAttendancePoints +
-              newRecordingPoints +
-              newAssignmentPoints +
-              newVideoPoints +
-              newArticlePoints;
-
-            await db
-              .update(zuvyLearnerLeaderboard)
-              .set(updateData)
-              .where(eq(zuvyLearnerLeaderboard.id, existing.id));
-
-            this.logger.debug(
-              `Updated leaderboard for learner ${entry.learnerId}, bootcamp ${entry.bootcampId}`,
+            updatePromises.push(
+              db
+                .update(zuvyLearnerLeaderboard)
+                .set(updateData)
+                .where(eq(zuvyLearnerLeaderboard.id, existing.id))
+                .then(() => {
+                  updatedCount++;
+                })
+                .catch((error) => {
+                  this.logger.error(
+                    `Failed to update leaderboard for learner ${entry.learnerId}, bootcamp ${entry.bootcampId}: ${this.getErrorMessage(
+                      error,
+                      'unknown error',
+                    )}`,
+                  );
+                }),
             );
           } else {
-            await db.insert(zuvyLearnerLeaderboard as any).values({
-              learnerId: entry.learnerId,
-              bootcampId: entry.bootcampId,
-              assessmentPoints: entry.assessmentPoints,
-              codingPoints: entry.codingPoints,
-              quizPoints: entry.quizPoints,
-              attendancePoints: entry.attendancePoints,
-              recordingPoints: entry.recordingPoints,
-              assignmentPoints: entry.assignmentPoints,
-              videoPoints: entry.videoPoints,
-              articlePoints: entry.articlePoints,
-
-              totalPoints: entry.totalPoints,
-              lastActivityAt: entry.lastActivityAt,
-              createdAt: new Date().toISOString(),
-              updatedAt: new Date().toISOString(),
-            });
-
-            this.logger.debug(
-              `Created leaderboard for learner ${entry.learnerId}, bootcamp ${entry.bootcampId}`,
-            );
+            // Mark as processed even if skipped to match original updatedCount behavior
+            updatedCount++;
           }
+        } else {
+          insertValues.push({
+            learnerId: entry.learnerId,
+            bootcampId: entry.bootcampId,
+            assessmentPoints: entry.assessmentPoints,
+            codingPoints: entry.codingPoints,
+            quizPoints: entry.quizPoints,
+            attendancePoints: entry.attendancePoints,
+            recordingPoints: entry.recordingPoints,
+            assignmentPoints: entry.assignmentPoints,
+            videoPoints: entry.videoPoints,
+            articlePoints: entry.articlePoints,
+            totalPoints: entry.totalPoints,
+            lastActivityAt: entry.lastActivityAt,
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+          });
+        }
+      }
 
-          updatedCount++;
+      // Execute insert in batches/bulk if any
+      if (insertValues.length > 0) {
+        try {
+          const chunkSize = 100;
+          for (let i = 0; i < insertValues.length; i += chunkSize) {
+            const chunk = insertValues.slice(i, i + chunkSize);
+            await db.insert(zuvyLearnerLeaderboard as any).values(chunk);
+          }
+          updatedCount += insertValues.length;
         } catch (error) {
           this.logger.error(
-            `Failed to update leaderboard for learner ${entry.learnerId}, bootcamp ${entry.bootcampId}: ${this.getErrorMessage(
+            `Failed to bulk insert leaderboard entries: ${this.getErrorMessage(
               error,
               'unknown error',
             )}`,
           );
         }
+      }
+
+      // Execute updates in parallel
+      if (updatePromises.length > 0) {
+        await Promise.all(updatePromises);
       }
 
       this.logger.log(

--- a/src/controller/leaderboard/leaderboard.service.ts
+++ b/src/controller/leaderboard/leaderboard.service.ts
@@ -812,15 +812,7 @@ export class LeaderboardService {
           lastActivityAt: new Date().toISOString(),
         };
 
-        this.logger.log(
-          `ASSIGNMENT LEADERBOARD DEBUG: learner=${submission.userId}, bootcamp=${submission.bootcampId}, chapter=${submission.chapterId}, attempt=${attemptPoints}, bonus=${bonusPoints}, total=${totalAssignmentPoints}`,
-        );
-
         entry.assignmentPoints += totalAssignmentPoints;
-
-        this.logger.log(
-          `ASSIGNMENT MAP TOTAL: learner=${submission.userId}, bootcamp=${submission.bootcampId}, assignmentPoints=${entry.assignmentPoints}`,
-        );
 
         const currentChapterPoints =
           entry.chapterPoints.get(submission.chapterId) ?? 0;

--- a/src/controller/leaderboard/leaderboard.service.ts
+++ b/src/controller/leaderboard/leaderboard.service.ts
@@ -716,6 +716,184 @@ export class LeaderboardService {
     }
   }
 
+  private async calculateVideoPoints(): Promise<
+    Map<
+      string,
+      {
+        videoPoints: number;
+        lastActivityAt: string;
+      }
+    >
+  > {
+    const videoMap = new Map<
+      string,
+      {
+        videoPoints: number;
+        lastActivityAt: string;
+      }
+    >();
+
+    try {
+      const videoCompletions = await db
+        .select({
+          userId: zuvyChapterTracking.userId,
+          chapterId: zuvyChapterTracking.chapterId,
+          bootcampId: zuvyCourseModules.bootcampId,
+          completedAt: zuvyChapterTracking.completedAt,
+        })
+        .from(zuvyChapterTracking)
+        .leftJoin(
+          zuvyModuleChapter,
+          eq(zuvyChapterTracking.chapterId, zuvyModuleChapter.id),
+        )
+        .leftJoin(
+          zuvyCourseModules,
+          eq(zuvyModuleChapter.moduleId, zuvyCourseModules.id),
+        )
+        .where(
+          and(
+            eq(zuvyModuleChapter.topicId, 1),
+            sql`${zuvyCourseModules.bootcampId} IS NOT NULL`,
+          ),
+        );
+
+      const completionsByLearnerBootcamp = new Map<string, Set<number>>();
+
+      for (const completion of videoCompletions) {
+        if (
+          !completion.userId ||
+          !completion.bootcampId ||
+          !completion.chapterId
+        ) {
+          continue;
+        }
+
+        const key = `${completion.userId}-${completion.bootcampId}`;
+
+        if (!completionsByLearnerBootcamp.has(key)) {
+          completionsByLearnerBootcamp.set(key, new Set());
+        }
+
+        completionsByLearnerBootcamp.get(key)!.add(completion.chapterId);
+
+        videoMap.set(key, {
+          videoPoints: 0,
+          lastActivityAt: completion.completedAt || new Date().toISOString(),
+        });
+      }
+
+      for (const [key, chapterSet] of completionsByLearnerBootcamp) {
+        const pointsPerVideo = 10;
+
+        const entry = videoMap.get(key);
+
+        if (entry) {
+          entry.videoPoints = chapterSet.size * pointsPerVideo;
+        }
+      }
+
+      return videoMap;
+    } catch (error) {
+      this.logger.error(
+        `Error calculating video points: ${this.getErrorMessage(
+          error,
+          'unknown error',
+        )}`,
+      );
+
+      return videoMap;
+    }
+  }
+
+  private async calculateArticlePoints(): Promise<
+    Map<
+      string,
+      {
+        articlePoints: number;
+        lastActivityAt: string;
+      }
+    >
+  > {
+    const articleMap = new Map<
+      string,
+      {
+        articlePoints: number;
+        lastActivityAt: string;
+      }
+    >();
+
+    try {
+      const articleCompletions = await db
+        .select({
+          userId: zuvyChapterTracking.userId,
+          chapterId: zuvyChapterTracking.chapterId,
+          bootcampId: zuvyCourseModules.bootcampId,
+          completedAt: zuvyChapterTracking.completedAt,
+        })
+        .from(zuvyChapterTracking)
+        .leftJoin(
+          zuvyModuleChapter,
+          eq(zuvyChapterTracking.chapterId, zuvyModuleChapter.id),
+        )
+        .leftJoin(
+          zuvyCourseModules,
+          eq(zuvyModuleChapter.moduleId, zuvyCourseModules.id),
+        )
+        .where(
+          and(
+            eq(zuvyModuleChapter.topicId, 2),
+            sql`${zuvyCourseModules.bootcampId} IS NOT NULL`,
+          ),
+        );
+
+      const completionsByLearnerBootcamp = new Map<string, Set<number>>();
+
+      for (const completion of articleCompletions) {
+        if (
+          !completion.userId ||
+          !completion.bootcampId ||
+          !completion.chapterId
+        ) {
+          continue;
+        }
+
+        const key = `${completion.userId}-${completion.bootcampId}`;
+
+        if (!completionsByLearnerBootcamp.has(key)) {
+          completionsByLearnerBootcamp.set(key, new Set());
+        }
+
+        completionsByLearnerBootcamp.get(key)!.add(completion.chapterId);
+
+        articleMap.set(key, {
+          articlePoints: 0,
+          lastActivityAt: completion.completedAt || new Date().toISOString(),
+        });
+      }
+
+      for (const [key, chapterSet] of completionsByLearnerBootcamp) {
+        const pointsPerArticle = 5;
+
+        const entry = articleMap.get(key);
+
+        if (entry) {
+          entry.articlePoints = chapterSet.size * pointsPerArticle;
+        }
+      }
+
+      return articleMap;
+    } catch (error) {
+      this.logger.error(
+        `Error calculating article points: ${this.getErrorMessage(
+          error,
+          'unknown error',
+        )}`,
+      );
+
+      return articleMap;
+    }
+  }
+
   async updateLeaderboard(): Promise<{
     success: boolean;
     message: string;
@@ -732,6 +910,8 @@ export class LeaderboardService {
         attendanceMap,
         recordingMap,
         assignmentMap,
+        videoMap,
+        articleMap,
       ] = await Promise.all([
         this.calculateAssessmentPoints(),
         this.calculateCodingPoints(),
@@ -739,6 +919,8 @@ export class LeaderboardService {
         this.calculateAttendancePoints(),
         this.calculateRecordingPoints(),
         this.calculateAssignmentPoints(),
+        this.calculateVideoPoints(),
+        this.calculateArticlePoints(),
       ]);
 
       const leaderboardMap = new Map<
@@ -752,6 +934,8 @@ export class LeaderboardService {
           attendancePoints: number;
           recordingPoints: number;
           assignmentPoints: number;
+          videoPoints: number;
+          articlePoints: number;
           totalPoints: number;
           lastActivityAt: string;
         }
@@ -764,6 +948,8 @@ export class LeaderboardService {
       attendanceMap.forEach((_, key) => allKeys.add(key));
       recordingMap.forEach((_, key) => allKeys.add(key));
       assignmentMap.forEach((_, key) => allKeys.add(key));
+      videoMap.forEach((_, key) => allKeys.add(key));
+      articleMap.forEach((_, key) => allKeys.add(key));
 
       for (const key of allKeys) {
         const [learnerId, bootcampId] = key.split('-').map(Number);
@@ -774,6 +960,8 @@ export class LeaderboardService {
         const attendanceEntry = attendanceMap.get(key);
         const recordingEntry = recordingMap.get(key);
         const assignmentEntry = assignmentMap.get(key);
+        const videoEntry = videoMap.get(key);
+        const articleEntry = articleMap.get(key);
 
         const assessmentPoints = assessmentEntry?.assessmentPoints || 0;
         const codingPoints = codingEntry?.codingPoints || 0;
@@ -781,6 +969,8 @@ export class LeaderboardService {
         const attendancePoints = attendanceEntry?.attendancePoints || 0;
         const recordingPoints = recordingEntry?.recordingPoints || 0;
         const assignmentPoints = assignmentEntry?.assignmentPoints || 0;
+        const videoPoints = videoEntry?.videoPoints || 0;
+        const articlePoints = articleEntry?.articlePoints || 0;
 
         const totalPoints =
           assessmentPoints +
@@ -788,7 +978,9 @@ export class LeaderboardService {
           quizPoints +
           attendancePoints +
           recordingPoints +
-          assignmentPoints;
+          assignmentPoints +
+          videoPoints +
+          articlePoints;
 
         const lastActivityAt =
           assessmentEntry?.lastActivityAt ||
@@ -797,6 +989,8 @@ export class LeaderboardService {
           attendanceEntry?.lastActivityAt ||
           recordingEntry?.lastActivityAt ||
           assignmentEntry?.lastActivityAt ||
+          videoEntry?.lastActivityAt ||
+          articleEntry?.lastActivityAt ||
           new Date().toISOString();
 
         leaderboardMap.set(key, {
@@ -808,6 +1002,8 @@ export class LeaderboardService {
           attendancePoints,
           recordingPoints,
           assignmentPoints,
+          videoPoints,
+          articlePoints,
           totalPoints,
           lastActivityAt,
         });
@@ -861,6 +1057,12 @@ export class LeaderboardService {
             const assignmentEntry = assignmentMap.get(
               `${entry.learnerId}-${entry.bootcampId}`,
             );
+            const videoEntry = videoMap.get(
+              `${entry.learnerId}-${entry.bootcampId}`,
+            );
+            const articleEntry = articleMap.get(
+              `${entry.learnerId}-${entry.bootcampId}`,
+            );
 
             const updateData: any = {
               lastActivityAt: entry.lastActivityAt,
@@ -877,6 +1079,9 @@ export class LeaderboardService {
               updateData.recordingPoints = recordingEntry.recordingPoints;
             if (assignmentEntry)
               updateData.assignmentPoints = assignmentEntry.assignmentPoints;
+            if (videoEntry) updateData.videoPoints = videoEntry.videoPoints;
+            if (articleEntry)
+              updateData.articlePoints = articleEntry.articlePoints;
 
             const newAssessmentPoints =
               assessmentEntry?.assessmentPoints ?? existing.assessmentPoints;
@@ -889,6 +1094,10 @@ export class LeaderboardService {
               recordingEntry?.recordingPoints ?? existing.recordingPoints;
             const newAssignmentPoints =
               assignmentEntry?.assignmentPoints ?? existing.assignmentPoints;
+            const newVideoPoints =
+              videoEntry?.videoPoints ?? existing.videoPoints;
+            const newArticlePoints =
+              articleEntry?.articlePoints ?? existing.articlePoints;
 
             updateData.totalPoints =
               newAssessmentPoints +
@@ -896,7 +1105,9 @@ export class LeaderboardService {
               newQuizPoints +
               newAttendancePoints +
               newRecordingPoints +
-              newAssignmentPoints;
+              newAssignmentPoints +
+              newVideoPoints +
+              newArticlePoints;
 
             await db
               .update(zuvyLearnerLeaderboard)
@@ -916,6 +1127,9 @@ export class LeaderboardService {
               attendancePoints: entry.attendancePoints,
               recordingPoints: entry.recordingPoints,
               assignmentPoints: entry.assignmentPoints,
+              videoPoints: entry.videoPoints,
+              articlePoints: entry.articlePoints,
+
               totalPoints: entry.totalPoints,
               lastActivityAt: entry.lastActivityAt,
               createdAt: new Date().toISOString(),

--- a/src/controller/progress/tracking.module.ts
+++ b/src/controller/progress/tracking.module.ts
@@ -11,6 +11,7 @@ import { ClassesModule } from '../classes/classes.module';
 import { ZoomModule } from 'src/services/zoom/zoom.module';
 import { AttendanceCalculationModule } from 'src/services/attendance/attendance-calculation.module';
 import { AttendanceReconciliationJob } from 'src/services/attendance/attendance-reconciliation.job';
+import { LeaderboardModule } from '../leaderboard/leaderboard.module';
 @Module({
   imports: [
     BatchesModule,
@@ -19,6 +20,7 @@ import { AttendanceReconciliationJob } from 'src/services/attendance/attendance-
     ClassesModule,
     ZoomModule,
     AttendanceCalculationModule,
+    LeaderboardModule,
   ],
   controllers: [TrackingController],
   providers: [TrackingService, JwtService, AttendanceReconciliationJob],

--- a/src/controller/progress/tracking.service.ts
+++ b/src/controller/progress/tracking.service.ts
@@ -54,6 +54,7 @@ import {
   resolveZoomAttendanceReadiness,
   resolveGoogleMeetAttendanceReadiness,
 } from 'src/services/attendance/attendance-readiness';
+import { LeaderboardService } from '../leaderboard/leaderboard.service';
 
 // Difficulty Points Mapping
 let { ACCEPTED, SUBMIT } = helperVariable;
@@ -66,6 +67,7 @@ export class TrackingService {
     private classesService: ClassesService,
     private readonly zoomService: ZoomService,
     private readonly attendanceCalc: AttendanceCalculationService,
+    private readonly leaderboardService: LeaderboardService,
   ) {}
 
   /**
@@ -541,6 +543,19 @@ export class TrackingService {
             chapter['chapterTrackingDetails'].length > 0
               ? 'Completed'
               : 'Pending';
+        });
+
+        const chapterIds = trackingData.map((chapter) => chapter.id);
+
+        const chapterPointsMap =
+          await this.leaderboardService.getChapterWisePoints(
+            userId,
+            moduleDetails[0].bootcampId,
+            chapterIds,
+          );
+
+        trackingData.forEach((chapter) => {
+          chapter['sparks'] = chapterPointsMap.get(chapter.id) ?? 0;
         });
 
         return {

--- a/src/controller/progress/tracking.service.ts
+++ b/src/controller/progress/tracking.service.ts
@@ -572,12 +572,6 @@ export class TrackingService {
 
         trackingData.forEach((chapter) => {
           chapter['sparks'] = chapterPointsMap.get(chapter.id) ?? 0;
-
-          const breakdown = assignmentBreakdownMap.get(chapter.id);
-
-          if (chapter.topicId === 5 && breakdown) {
-            chapter['breakdown'] = breakdown;
-          }
         });
 
         return {

--- a/src/controller/progress/tracking.service.ts
+++ b/src/controller/progress/tracking.service.ts
@@ -563,7 +563,7 @@ export class TrackingService {
 
         const chapterIds = trackingData.map((chapter) => chapter.id);
 
-        const chapterPointsMap =
+        const { chapterPointsMap, assignmentBreakdownMap } =
           await this.leaderboardService.getChapterWisePoints(
             userId,
             moduleDetails[0].bootcampId,
@@ -572,6 +572,12 @@ export class TrackingService {
 
         trackingData.forEach((chapter) => {
           chapter['sparks'] = chapterPointsMap.get(chapter.id) ?? 0;
+
+          const breakdown = assignmentBreakdownMap.get(chapter.id);
+
+          if (chapter.topicId === 5 && breakdown) {
+            chapter['breakdown'] = breakdown;
+          }
         });
 
         return {


### PR DESCRIPTION
Implemented chapter-wise sparks scoring and updated leaderboard scoring logic while keeping assessment and standalone chapter scoring separate.

## Changes Made

- Added  "sparks calculation for completed chapters" based on chapter topic.
- Added standalone chapter scoring for:
  - Video chapters
  - Article chapters
  - Coding chapters
  - Quiz chapters
  - Assignment chapters
- Added  "assignment attempt points" and  "on-time submission bonus".
- Updated quiz scoring to support standalone quiz chapter completion.
- Kept "assessment-level Coding and Quiz scoring separate" from standalone chapter sparks.
- Ensured completed Coding and Quiz chapters can display their respective sparks.
- Preserved existing leaderboard scoring categories and business logic.
- Kept pending chapters at `0` sparks.
- Updated chapter-wise points mapping so sparks are returned correctly in the tracking API..

Performance optimization should be handled separately without changing the existing scoring/business logic for:
- `/leaderboard/update`
- `/tracking/getAllChaptersWithStatus/{moduleId}`
